### PR TITLE
Add alignment to @mamba/input and default it to the right

### DIFF
--- a/packages/components/Input/src/Input.svelte
+++ b/packages/components/Input/src/Input.svelte
@@ -9,6 +9,7 @@
 
   <input
     ref:input
+    class="-{align}"
     type={visible ? 'text' : 'password'}
     style="color: {textColor}"
     {disabled}
@@ -41,6 +42,7 @@
     },
     data() {
       return {
+        align: 'right',
         visible: true,
         value: '',
         validate: undefined,
@@ -177,7 +179,7 @@
   }
 
   .input.-password input {
-    padding-right: 35px;
+    padding-right: 40px;
   }
 
   span {
@@ -198,6 +200,10 @@
     border-bottom: 1px dotted #dedede;
   }
 
+  input:not(.-left) {
+    text-align: right;
+  }
+
   input[type='text'] {
     font-size: 20px;
   }
@@ -205,7 +211,7 @@
   .type-toggle {
     position: absolute;
     right: 20px;
-    bottom: 10px;
+    bottom: 17px;
   }
 
   .validation-msg {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- Set the Jira issue number on the link -->

Padroniza o alinhamento dos Inputs à direita e permite definir o alinhamento à esquerda