### PR TITLE
Fix @mamba/input scroll into view changing the @mamba/pos position

### DIFF
--- a/packages/components/Input/src/Input.svelte
+++ b/packages/components/Input/src/Input.svelte
@@ -74,13 +74,13 @@
 
         if (autofocus) {
           this.focus()
-          this.refs.input.scrollIntoView()
+          this.refs.input.scrollIntoView(false)
         }
       }
     },
     onupdate({ changed, current }) {
       if (changed.errorMsg && current.errorMsg) {
-        this.refs.input.scrollIntoView()
+        this.refs.input.scrollIntoView(false)
       }
     },
     methods: {


### PR DESCRIPTION
The `@mamba/input` component was scrolling the whole page to align the actual input to the top of the window, breaking the `@mamba/pos` position.