### PR TITLE
-WEBSDK-177-fix-onstate

### DIFF
--- a/packages/components/AppBar/src/AppBarTitle.html
+++ b/packages/components/AppBar/src/AppBarTitle.html
@@ -1,7 +1,6 @@
 <script>
   export default {
-    /** We use onstate to fire the event before things are rendered */
-    onstate({ previous }) {
+    onupdate({ previous }) {
       if (!previous) {
         if (!this.store) {
           throw new Error(

--- a/packages/components/Dialog/src/PromisedDialog.html
+++ b/packages/components/Dialog/src/PromisedDialog.html
@@ -21,7 +21,7 @@
         return tmp;
       },
     },
-    onstate({ changed, current: { promise, delay } }) {
+    onupdate({ changed, current: { promise, delay } }) {
       if (changed.promise && promise && typeof promise.then === 'function') {
         promise
           .then(() => {
@@ -30,7 +30,7 @@
               this.fire('success');
             }, parseFloat(delay));
           })
-          .catch((e) => {
+          .catch(e => {
             setTimeout(() => {
               this.refs.dialog.close();
               this.fire('failure', e);

--- a/packages/components/Icon/src/Icon.html
+++ b/packages/components/Icon/src/Icon.html
@@ -9,7 +9,7 @@
         level: undefined,
       };
     },
-    onstate({ current: { color, src } }) {
+    onupdate({ current: { color, src } }) {
       const iconEl = this.refs.icon;
 
       if (color) {


### PR DESCRIPTION
[WEBSDK-177](https://stonepayments.atlassian.net/browse/WEBSDK-177)

- Svelte 2.11 changed the behaviour of the `onstate` lifecycle hooke. We must use `onupdate` if we want to manually modify the DOM after a state change.