### PR TITLE
Add rule linebreak

### DIFF
--- a/packages/configs/eslint/index.js
+++ b/packages/configs/eslint/index.js
@@ -57,7 +57,7 @@ module.exports = {
     /** Allow __variables__ with underscores */
     'no-underscore-dangle': 'off',
 
-    /** Rule enforces consisten */
+    /** Allow both LF and CRLF line endings */
     'linebreak-style': 'off',
 
     /** Max line length */

--- a/packages/configs/eslint/index.js
+++ b/packages/configs/eslint/index.js
@@ -57,6 +57,9 @@ module.exports = {
     /** Allow __variables__ with underscores */
     'no-underscore-dangle': 'off',
 
+    /** Rule enforces consisten */
+    'linebreak-style': 'off',
+
     /** Max line length */
     'max-len': [
       'warn',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- Set the Jira issue number on the link -->

[WEBSDK-XXXX](https://stonepayments.atlassian.net/browse/WEBSDK-XXXX)

<!-- Describe the big picture of your changes here -->
Linux e Unix(LF - \n) e Windows(CRLF - \r\n) causam problemas de linebreak no build, colocando a regra de desabilitar final de linha, mantendo um padrão consistente.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Describe in detail how you tested your changes -->

## Screenshots (if appropriate):
<!-- Add screenshots here, if appropriate -->

## Further Comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
