### PR TITLE
Ponto de entrada virtual para o build de App

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,8 +151,6 @@
     "webpack-dev-server": "^3.1.9",
     "webpack-merge": "^4.1.4",
     "webpack-sources": "^1.3.0",
-    "xmlbuilder": "^10.0.0",
-    "yargonaut": "^1.1.4",
-    "yargs": "^12.0.2"
+    "xmlbuilder": "^10.0.0"
   }
 }

--- a/packages/webpack/config.base.js
+++ b/packages/webpack/config.base.js
@@ -1,9 +1,12 @@
 /**
  * Common webpack configuration
  */
+const { readFileSync } = require('fs');
+const { resolve } = require('path');
 const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const VirtualModulesPlugin = require('webpack-virtual-modules');
 const webpack = require('webpack');
 const { fromCwd } = require('quickenv');
 
@@ -32,7 +35,7 @@ const entry = {
     '@mamba/styles/dist/pos.css',
     /** Mamba simulator entry point */
     ADD_MAMBA_SIMULATOR && './simulator.js',
-    /** App entry point */
+    /** Virtual app entry point */
     './index.js',
   ].filter(Boolean),
 };
@@ -141,6 +144,12 @@ module.exports = {
     ],
   },
   plugins: [
+    new VirtualModulesPlugin({
+      /** ! Virtual entry point for the app */
+      './index.js': readFileSync(
+        resolve(__dirname, 'helpers', 'appEntryPoint.js'),
+      ),
+    }),
     /** Prepend the Function.prototype.bind() polyfill webpack's runtime code */
     new MambaFixesPlugin(),
     new ProgressBarPlugin(),

--- a/packages/webpack/helpers/appEntryPoint.js
+++ b/packages/webpack/helpers/appEntryPoint.js
@@ -1,0 +1,9 @@
+/**
+ * Mamba App entrypoint.
+ * Since this file is barely modified, we include it
+ * automatically as a virtual module.
+ */
+import { initApp } from '@mamba/pos/utils.js';
+import App from './App.html';
+
+export default initApp(App);

--- a/packages/webpack/helpers/appEntryPoint.js
+++ b/packages/webpack/helpers/appEntryPoint.js
@@ -4,6 +4,6 @@
  * automatically as a virtual module.
  */
 import { initApp } from '@mamba/pos/utils.js';
-import App from './App.html';
+import App from './index.html';
 
 export default initApp(App);

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -48,6 +48,7 @@
     "webpack-dev-server": "^3.1.9",
     "webpack-merge": "^4.1.4",
     "webpack-sources": "^1.3.0",
+    "webpack-virtual-modules": "^0.1.10",
     "xmlbuilder": "^10.0.0"
   },
   "gitHead": "91a8a4a8be4741a15249462cefda6e273f1613a3"


### PR DESCRIPTION
O arquivo `index.js` dos apps é muito pequeno e sempre será o mesmo, portanto, o `webpack` se encarregará de carregá-lo da memória, e não do HD, deixando o `entrypoint` do app no componente raiz em `index.html`