### PR TITLE
Handle httpWrapper requestFailed signal

### DIFF
--- a/packages/pos/drivers/http/simulation.js
+++ b/packages/pos/drivers/http/simulation.js
@@ -2,7 +2,7 @@ import { log } from '../../simulator/libs/utils.js';
 
 export const NAMESPACE = '$Http';
 
-export const SIGNALS = ['requestFinished'];
+export const SIGNALS = ['requestFinished', 'requestFailed'];
 
 export function setup(Http) {
   let _errorData = null;
@@ -25,7 +25,7 @@ export function setup(Http) {
         status: this.status,
         msg: this.responseText,
       });
-      Http.requestFinished();
+      Http.requestFailed();
     };
 
     xhttp.onreadystatechange = function onreadystatechange() {

--- a/packages/pos/drivers/http/wrappers.js
+++ b/packages/pos/drivers/http/wrappers.js
@@ -1,10 +1,10 @@
 export default function(driver) {
   driver.send = function send(configParams) {
     return new Promise((resolve, reject) => {
+      driver.once('requestFailed', () => {
+        return reject(driver.getError());
+      });
       driver.once('requestFinished', () => {
-        if (driver.getError()) {
-          return reject(driver.getError());
-        }
         resolve(driver.getData());
       });
 

--- a/packages/pos/drivers/http/wrappers.js
+++ b/packages/pos/drivers/http/wrappers.js
@@ -1,12 +1,10 @@
 export default function(driver) {
   driver.send = function send(configParams) {
     return new Promise((resolve, reject) => {
-      driver.once('requestFailed', () => {
-        return reject(driver.getError());
-      });
-      driver.once('requestFinished', () => {
-        resolve(driver.getData());
-      });
+      driver.race([
+        ['requestFailed', () => reject(driver.getError())],
+        ['requestFinished', () => resolve(driver.getData())],
+      ]);
 
       /** Asynchronously make a request at the backend */
       driver.doSend(configParams);


### PR DESCRIPTION
O promisse de http estava sempre dando reject e nunca resolve, isso porque quando o send dá sucesso driver.getError() retorna um QMap() vazio que mesmo assim é um objeto válido, assim if(driver.getError()) era sempre true.
Troquei para utilizar o signal requestFailed que já é emitido pelo back na 2.4.1 também, mantendo compativel com os POS do parque.