### PR TITLE
Generalize the simulator usage 

### DIFF
--- a/packages/configs/eslint/index.js
+++ b/packages/configs/eslint/index.js
@@ -32,7 +32,7 @@ module.exports = {
     __DEV__: true,
     __DEBUG_LVL__: true,
     __SIMULATOR__: true,
-    __MANIFEST__: true,
+    __APP_MANIFEST__: true,
   },
   rules: {
     // ! Code

--- a/packages/pos/drivers/app/simulation.js
+++ b/packages/pos/drivers/app/simulation.js
@@ -5,7 +5,9 @@ export const NAMESPACE = '$App';
 export const SIGNALS = ['opened', 'closed'];
 
 export function setup(App) {
-  App.doClose = () => Core.AppManager.close();
+  App.doClose = __TEST__
+    ? () => App.fire('closed')
+    : () => Core.AppManager.close();
 
   App.getAppKey = () => '123456';
 

--- a/packages/pos/package.json
+++ b/packages/pos/package.json
@@ -16,7 +16,8 @@
     "@mamba/button": "^2.0.0",
     "@mamba/icon": "^2.0.0",
     "@mamba/styles": "^2.0.0",
-    "@mamba/switch": "^2.0.0"
+    "@mamba/switch": "^2.0.0",
+    "immer": "^1.8.2"
   },
   "gitHead": "7118f44e933d2f656166a80822c0b3c1001e6a33"
 }

--- a/packages/pos/simulator/plugins/app/manager.js
+++ b/packages/pos/simulator/plugins/app/manager.js
@@ -1,4 +1,3 @@
-import DriverManager from '../driver/manager.js';
 import Signal from '../../libs/signal.js';
 import App from '../../../api/app.js';
 import extendDriver from '../../../drivers/extend.js';
@@ -27,12 +26,6 @@ AppManager.installApp = (AppConstructor, manifest) => {
       constructor: AppConstructor,
       manifest,
     };
-
-    const looseDrivers = DriverManager.getLooseDrivers();
-    if (looseDrivers) {
-      appMetaObj.drivers = looseDrivers;
-      DriverManager.clearLooseDrivers();
-    }
 
     Apps[manifest.slug] = appMetaObj;
 
@@ -106,12 +99,6 @@ AppManager.close = () => {
           },
         );
       });
-
-      if (currentApp.drivers) {
-        currentApp.drivers.forEach(driverModule => {
-          DriverManager.resetDriverState(driverModule);
-        });
-      }
 
       currentApp = null;
     } else if (__DEV__) {

--- a/packages/pos/simulator/plugins/app/manager.js
+++ b/packages/pos/simulator/plugins/app/manager.js
@@ -12,9 +12,9 @@ let currentApp = null;
 
 Signal.register(AppManager, [
   'appInstalled',
-  'willOpen',
+  'opening',
   'opened',
-  'willClose',
+  'closing',
   'closed',
 ]);
 
@@ -38,15 +38,15 @@ AppManager.installApp = (AppConstructor, manifest) => {
   }
 };
 
-AppManager.open = appSlug => {
-  AppManager.fire('willOpen');
-
-  const target = document.getElementById('app-root');
-
+AppManager.open = (appSlug, options = {}) => {
   /** First time opening an app */
   const appMetaObj = Apps[appSlug];
 
+  AppManager.fire('opening', appMetaObj, options);
+
   if (__DEV__) log(`Opening App: ${appMetaObj.manifest.appName}`);
+
+  const target = document.getElementById('app-root');
 
   if (!target) {
     if (__DEV__) {
@@ -63,7 +63,7 @@ AppManager.open = appSlug => {
   currentApp = appMetaObj;
   currentApp.runtime.instance = new appMetaObj.constructor({ target });
 
-  AppManager.fire('opened', currentApp);
+  AppManager.fire('opened', appMetaObj, options);
   App.fire('opened');
 };
 
@@ -71,7 +71,7 @@ AppManager.close = () => {
   if (__DEV__) log('Closing App');
 
   if (currentApp) {
-    AppManager.fire('willClose', currentApp);
+    AppManager.fire('closing', currentApp);
 
     App.fire('closed');
 

--- a/packages/pos/simulator/plugins/app/manager.js
+++ b/packages/pos/simulator/plugins/app/manager.js
@@ -7,6 +7,7 @@ import initEventCollector from './includes/eventCollector.js';
 const AppManager = extendDriver({}, initEventCollector);
 
 const Apps = {};
+
 let currentApp = null;
 
 Signal.register(AppManager, [
@@ -37,10 +38,10 @@ AppManager.installApp = (AppConstructor, manifest) => {
   }
 };
 
-AppManager.open = (appSlug, target) => {
+AppManager.open = appSlug => {
   AppManager.fire('willOpen');
 
-  target = target || document.getElementById('app-root');
+  const target = document.getElementById('app-root');
 
   /** First time opening an app */
   const appMetaObj = Apps[appSlug];

--- a/packages/pos/simulator/plugins/app/manager.js
+++ b/packages/pos/simulator/plugins/app/manager.js
@@ -62,18 +62,18 @@ AppManager.open = (appSlug, target) => {
   currentApp = appMetaObj;
   currentApp.runtime.instance = new appMetaObj.constructor({ target });
 
-  AppManager.fire('opened');
+  AppManager.fire('opened', currentApp);
   App.fire('opened');
 };
 
 AppManager.close = () => {
-  AppManager.fire('willClose');
-
   if (__DEV__) log('Closing App');
 
-  App.fire('closed');
-
   if (currentApp) {
+    AppManager.fire('willClose', currentApp);
+
+    App.fire('closed');
+
     if (currentApp.runtime.instance) {
       const { runtime } = currentApp;
       runtime.instance.destroy();
@@ -100,13 +100,13 @@ AppManager.close = () => {
         );
       });
 
+      AppManager.fire('closed', currentApp);
+
       currentApp = null;
     } else if (__DEV__) {
       warn('App already closed');
     }
   }
-
-  AppManager.fire('closed');
 };
 
 export default AppManager;

--- a/packages/pos/simulator/plugins/registry/includes/data.js
+++ b/packages/pos/simulator/plugins/registry/includes/data.js
@@ -1,4 +1,8 @@
+import produce, { setAutoFreeze } from 'immer';
+
 import { log } from '../../../libs/utils.js';
+
+setAutoFreeze(false);
 
 export default Registry => {
   /** Data */
@@ -12,11 +16,21 @@ export default Registry => {
     for (let i = 1; i < keys.length; i++) {
       value = value[keys[i]];
     }
+
+    if (typeof value === 'object') {
+      return JSON.parse(JSON.stringify(value));
+    }
+
     return value;
   };
 
   Registry.set = (keyPath, value, fireSignal = true) => {
     if (keyPath === undefined) {
+      return;
+    }
+
+    if (typeof keyPath === 'function') {
+      Registry._data = produce(Registry._data, keyPath);
       return;
     }
 

--- a/packages/pos/simulator/plugins/view/Launcher.html
+++ b/packages/pos/simulator/plugins/view/Launcher.html
@@ -49,6 +49,20 @@
     APP: 2,
   };
 
+  const APP_INDEXES = [
+    'payment',
+    'cancellation',
+    'calculator',
+    'reprint',
+    'reports',
+    'closing',
+    'config',
+    'help',
+  ].reduce((acc, name, index) => {
+    acc[name] = index;
+    return acc;
+  }, {});
+
   export default {
     components: {
       Button: '@mamba/button',
@@ -66,7 +80,16 @@
       };
     },
     computed: {
-      appsList: ({ apps }) => Object.values(apps),
+      appsList: ({ apps }) =>
+        Object.values(apps).reduce((acc, app) => {
+          const { name } = app.manifest;
+          if (typeof APP_INDEXES[name] !== 'undefined') {
+            acc.splice(APP_INDEXES[name], 0, app);
+          } else {
+            acc.push(app);
+          }
+          return acc;
+        }, []),
     },
     oncreate() {
       window.history.replaceState('', document.title, window.location.pathname);

--- a/packages/pos/simulator/plugins/view/Launcher.html
+++ b/packages/pos/simulator/plugins/view/Launcher.html
@@ -3,7 +3,7 @@
 {:else}
   <SignalListener driver={Card} on:cardInserted="openPaymentApp()"/>
 
-  <div class="launcher">
+  <div class="launcher hide-scrollbars">
     {#if STATE === STATES.LOCKSCREEN}
       <div class="lockscreen">
         <time>{time}</time>

--- a/packages/pos/simulator/plugins/view/Launcher.html
+++ b/packages/pos/simulator/plugins/view/Launcher.html
@@ -69,6 +69,8 @@
       appsList: ({ apps }) => Object.values(apps),
     },
     oncreate() {
+      window.history.replaceState('', document.title, window.location.pathname);
+
       /** Update the clock after each second */
       Registry.on('clock', (newHours, newMinutes) => {
         this.set({ time: `${newHours}:${newMinutes}` });

--- a/packages/pos/simulator/plugins/view/Launcher.html
+++ b/packages/pos/simulator/plugins/view/Launcher.html
@@ -110,7 +110,7 @@
       });
 
       /** Listen to an app being opened and guarantee the Launcher is ready to open it */
-      AppManager.on('willOpen', () => {
+      AppManager.on('opening', () => {
         const { STATE } = this.get();
         if (STATE !== STATES.APP) {
           this.set({ STATE: STATES.APP });
@@ -131,11 +131,7 @@
         const { apps } = this.get();
 
         if (apps['1-payment']) {
-          Registry.set(draft => {
-            draft.PaymentApp.paymentConfig.openMode = 'detection';
-          });
-
-          this.openApp(apps['1-payment']);
+          this.openApp(apps['1-payment'], { openMode: 'detection' });
         } else {
           // TODO: fake payment app
           warn(
@@ -143,9 +139,9 @@
           );
         }
       },
-      openApp(appMeta) {
+      openApp(appMeta, options) {
         this.set({ STATE: STATES.APP });
-        AppManager.open(appMeta.manifest.slug);
+        AppManager.open(appMeta.manifest.slug, options);
       },
       gotoLockscreen() {
         this.set({ STATE: STATES.LOCKSCREEN });

--- a/packages/pos/simulator/plugins/view/Launcher.html
+++ b/packages/pos/simulator/plugins/view/Launcher.html
@@ -1,6 +1,8 @@
 {#if STATE === STATES.APP}
   <div ref:approot id="app-root" class="hide-scrollbar"></div>
 {:else}
+  <SignalListener driver={Card} on:cardInserted="openPaymentApp()"/>
+
   <div class="launcher">
     {#if STATE === STATES.LOCKSCREEN}
       <div class="lockscreen">
@@ -38,10 +40,11 @@
 {/if}
 
 <script>
+  import { warn } from '../../libs/utils.js';
   import AppManager from '../app/manager.js';
   import Registry from '../registry/manager.js';
-
-  const { hours: initHours, minutes: initMinutes } = Registry.getCurrentTime();
+  import Card from '../../../api/card.js';
+  import SignalListener from '../../../SignalListener.html';
 
   const STATES = {
     LOCKSCREEN: 0,
@@ -68,11 +71,18 @@
       Button: '@mamba/button',
       Icon: '@mamba/icon',
       Keystroke: '@mamba/app/Keystroke.html',
+      SignalListener,
     },
     helpers: {
       STATES,
+      Card,
     },
     data() {
+      const {
+        hours: initHours,
+        minutes: initMinutes,
+      } = Registry.getCurrentTime();
+
       return {
         STATE: STATES.LOCKSCREEN,
         time: `${initHours}:${initMinutes}`,
@@ -117,6 +127,22 @@
         });
     },
     methods: {
+      openPaymentApp() {
+        const { apps } = this.get();
+
+        if (apps['1-payment']) {
+          Registry.set(draft => {
+            draft.PaymentApp.paymentConfig.openMode = 'detection';
+          });
+
+          this.openApp(apps['1-payment']);
+        } else {
+          // TODO: fake payment app
+          warn(
+            "Should open payment app but it's not installed\nTODO: placeholder payment app.",
+          );
+        }
+      },
       openApp(appMeta) {
         this.set({ STATE: STATES.APP });
         AppManager.open(appMeta.manifest.slug);

--- a/packages/pos/simulator/plugins/view/Launcher.html
+++ b/packages/pos/simulator/plugins/view/Launcher.html
@@ -59,7 +59,7 @@
     'reprint',
     'reports',
     'closing',
-    'config',
+    'settings',
     'help',
   ].reduce((acc, name, index) => {
     acc[name] = index;

--- a/packages/pos/simulator/plugins/view/style.pcss
+++ b/packages/pos/simulator/plugins/view/style.pcss
@@ -21,3 +21,10 @@
 :global(.hide-scrollbar) {
   @extend %hide-scrollbar;
 }
+
+:global(.hide-scrollbars) {
+  &,
+  :global(*) {
+    @extend %hide-scrollbar;
+  }
+}

--- a/packages/webpack/config.app.js
+++ b/packages/webpack/config.app.js
@@ -30,7 +30,7 @@ module.exports = merge(require('./config.base.js'), {
       };
 
       if (IS_BROWSER) {
-        aliases['%mamba_app_icon_path%$'] = fromCwd('src', PKG.mamba.iconPath);
+        aliases.__APP_ICON__ = fromCwd('src', PKG.mamba.iconPath);
       }
 
       return aliases;
@@ -49,18 +49,14 @@ module.exports = merge(require('./config.base.js'), {
     new VirtualModulesPlugin(getVirtualFiles()),
     /** Prepend the Function.prototype.bind() polyfill webpack's runtime code */
     new MambaFixesPlugin(),
-    new webpack.DefinePlugin(
-      (() => {
-        const __MANIFEST__ = {
-          name: PKG.name,
-          description: PKG.description,
-          version: PKG.version,
-          slug: `${PKG.mamba.id}-${PKG.name}`,
-          ...PKG.mamba,
-        };
-
-        return { __MANIFEST__: JSON.stringify(__MANIFEST__) };
-      })(),
-    ),
+    new webpack.DefinePlugin({
+      __APP_MANIFEST__: JSON.stringify({
+        name: PKG.name,
+        description: PKG.description,
+        version: PKG.version,
+        slug: `${PKG.mamba.id}-${PKG.name}`,
+        ...PKG.mamba,
+      }),
+    }),
   ],
 });

--- a/packages/webpack/config.base.js
+++ b/packages/webpack/config.base.js
@@ -4,6 +4,7 @@
 const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
 const WebpackBar = require('webpackbar');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const OfflinePlugin = require('offline-plugin');
 const webpack = require('webpack');
 const { fromCwd } = require('quickenv');
 
@@ -137,6 +138,7 @@ module.exports = {
       __SIMULATOR__: ADD_MAMBA_SIMULATOR,
       __BROWSER__: IS_BROWSER,
     }),
+    new OfflinePlugin(),
   ],
   /** Minimal useful output log */
   stats: {

--- a/packages/webpack/config.base.js
+++ b/packages/webpack/config.base.js
@@ -4,7 +4,6 @@
 const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
 const WebpackBar = require('webpackbar');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const OfflinePlugin = require('offline-plugin');
 const webpack = require('webpack');
 const { fromCwd } = require('quickenv');
 
@@ -138,7 +137,6 @@ module.exports = {
       __SIMULATOR__: ADD_MAMBA_SIMULATOR,
       __BROWSER__: IS_BROWSER,
     }),
-    new OfflinePlugin(),
   ],
   /** Minimal useful output log */
   stats: {

--- a/packages/webpack/virtual-files/index.browser.js
+++ b/packages/webpack/virtual-files/index.browser.js
@@ -1,9 +1,9 @@
 import { AppManager } from '@mamba/pos/simulator/index.js';
-import icon from '%mamba_app_icon_path%'; // eslint-disable-line
+import icon from '__APP_ICON__'; // eslint-disable-line
 import App from './index.html';
 
-/** __MANIFEST__ is replaced with the current app's manifest */
-const manifest = __MANIFEST__;
+/** __APP_MANIFEST__ is replaced with the current app's manifest */
+const manifest = __APP_MANIFEST__;
 manifest.icon = icon;
 
 AppManager.installApp(App, manifest);


### PR DESCRIPTION
A gente tava usando um conceito de `drivers` externos que um app poderia ter e os resetando conforme o app fosse fechado no simulador. Entretanto, o "reset" do estado de um driver deveria ser responsabilidade do próprio driver e não do simulador.