### PR TITLE
Modify row height to be 44px

### DIFF
--- a/packages/components/Collection/Row.html
+++ b/packages/components/Collection/Row.html
@@ -185,7 +185,7 @@
     width: 100%;
     justify-content: space-between;
     align-items: center;
-    height: 20px;
+    height: $row-top-height;
   }
 
   .left-area {

--- a/packages/components/Collection/Row.html
+++ b/packages/components/Collection/Row.html
@@ -185,7 +185,7 @@
     width: 100%;
     justify-content: space-between;
     align-items: center;
-    height: 25px;
+    height: 20px;
   }
 
   .left-area {

--- a/packages/configs/postcss/includes/uniqueImports.js
+++ b/packages/configs/postcss/includes/uniqueImports.js
@@ -25,7 +25,7 @@ postcssUniqueImports.plugin = (...opts) => {
       if (typeof initialImports === 'string') {
         imports = [initialImports];
       } else if (initialImports.length) {
-        imports = initialImports.filter(Boolean).reverse();
+        imports = initialImports.filter(Boolean);
       }
     }
 

--- a/packages/styles/theme.pcss
+++ b/packages/styles/theme.pcss
@@ -7,7 +7,7 @@ $app-bg-color: $gray-lighter;
 
 /** Row component */
 $row-padding: 12px 15px;
-$row-top-height: 15px;
+$row-top-height: 20px;
 $row-border-color: $gray-lighter;
 $row-bg-color: $white;
 $row-primary-color: $gray-darker;

--- a/packages/styles/theme.pcss
+++ b/packages/styles/theme.pcss
@@ -7,6 +7,7 @@ $app-bg-color: $gray-lighter;
 
 /** Row component */
 $row-padding: 12px 15px;
+$row-top-height: 15px;
 $row-border-color: $gray-lighter;
 $row-bg-color: $white;
 $row-primary-color: $gray-darker;


### PR DESCRIPTION
A altura de 50px pra todas as `Row`s tá um pouco exagerada para a maior parte dos casos e uma `Row` acaba ocupando muito espaço. Antes estavam com `40px` e, para alinhar com o design previsto, trocamos para `49px`. Entretanto, conversando com o Gallez, vimos que algumas `Row`s tem 44px (+1 de borda) de altura e, como a diferença visual entre 49px e 44px é muito pequena, proponho normalizarmos todas as `Row`s com 44px. O ganho de 5px para cada `Row` na tela é bem significativo caso existam várias