### PR TITLE
internal: 🏭 fix firefox scroll breaking

### DIFF
--- a/packages/pos/simulator/view/pos/hardware/Screen.html
+++ b/packages/pos/simulator/view/pos/hardware/Screen.html
@@ -83,6 +83,7 @@
 
     .screen {
       height: 100%;
+      filter: url(#pos-color-map);
     }
   }
 

--- a/packages/pos/simulator/view/pos/hardware/Screen.html
+++ b/packages/pos/simulator/view/pos/hardware/Screen.html
@@ -97,6 +97,11 @@
       flex-flow: column;
       overflow: hidden;
       filter: url(#pos-color-map);
+
+      /** Firefox is being annoyed by two stack contexts (.screen and .content) and breaking the scroll */
+      @supports (-moz-appearance: none) {
+        filter: none;
+      }
     }
 
     .content {


### PR DESCRIPTION
Firefox is behaving strangely when two stack-contexts are together
(translateZ(0) and filter). To fix this, the color map filter is now
applied only when running the simulator not on firefox.