### PR TITLE
feat: 🎸 Create operating mode by route

### DIFF
--- a/packages/components/App/package.json
+++ b/packages/components/App/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/button": "^2.8.2",
     "@mamba/styles": "^2.8.2"

--- a/packages/components/AppBar/package.json
+++ b/packages/components/AppBar/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "dependencies": {
     "@mamba/icon": "^2.8.2"
   },

--- a/packages/components/Barcode/package.json
+++ b/packages/components/Barcode/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "dependencies": {
     "@mamba/styles": "^2.8.2",
     "jsbarcode": "^3.11.0"

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/icon": "^2.8.2"
   },

--- a/packages/components/Collection/package.json
+++ b/packages/components/Collection/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/switch": "^2.8.2"
   },

--- a/packages/components/Dialog/package.json
+++ b/packages/components/Dialog/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/sprite": "^2.8.2"
   },

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "dependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/Printable/package.json
+++ b/packages/components/Printable/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/Progress/package.json
+++ b/packages/components/Progress/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "dependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/QRCode/package.json
+++ b/packages/components/QRCode/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "dependencies": {
     "@mamba/styles": "^2.8.2",
     "qrious": "^4.0.2"

--- a/packages/components/Range/package.json
+++ b/packages/components/Range/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "dependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/Sprite/package.json
+++ b/packages/components/Sprite/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -7,9 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/styles": "^2.8.2"
   },

--- a/packages/components/Tabs/README.md
+++ b/packages/components/Tabs/README.md
@@ -2,8 +2,9 @@
 
 O módulo `Tabs` é responsável por exibir uma lista de abas, possibilitando a troca de conteúdo de acordo com a sua seleção.
 
-## Como utilizar
+Usar o modo de funcionamento `route` do parâmetro `changeOn`, faz com que a troca das abas seja feita pela rota da aplicação. Isso é útil para lembrar a posição do índice da aba para rotas internas, e voltar na história do navegador, ou para quando você quiser entrar um uma página exibindo um índice específico.
 
+## Como utilizar
 
 ```js
 import Tabs from '@mamba/tabs/Tabs.html';
@@ -18,29 +19,35 @@ import TabPane from '@mamba/tabs/TabPane.html';
 </Tabs>
 ```
 
-
 ## TabPane
 
 O `TabPane` é um wrapper sem funcionalidades, gerenciado pelo seu componente pai `Tabs`. Os items da `Tabs` são renderizados na ordem em que os `TabPane` são declarados.
 <br/><br/>
 O atributo `title` será usado como label no item da aba.
 Omitir o attributo `title`, resulta a aba e seu contúdo correspondente não ser exibido.
-
+Para que o parâmetro `route` funcionar corretamente, é necessário que o caminho da aba seja completo e absoluto, incluindo a rota do pai.
 
 <!-- @example ./example/Example.html -->
 
 ## Parâmetros
 
+`<Tabs ...props />`
+
+| Parâmetro | Descrição                                                            | Tipo     | Padrão  |
+| --------- | -------------------------------------------------------------------- | -------- | ------- |
+| changeOn  | Define qual o modo de funcionamento das abas: por `state` ou `route` | `string` | `state` |
+
 `<TabPane ...props />`
 
-| Parâmetro   | Descrição                         | Tipo               | Padrão        |
-|-------------|-----------------------------------|--------------------|---------------|
-| title       | Título a ser utilizado para criar o item na navegação de abas        | `string`           | `undefined`   |
+| Parâmetro | Descrição                                                                   | Tipo     | Padrão      |
+| --------- | --------------------------------------------------------------------------- | -------- | ----------- |
+| title     | Título a ser utilizado para criar o item na navegação de abas               | `string` | `undefined` |
+| route     | Rota da aba para ser usada com modo de troca por `route` do modo `changeOn` | `string` | `undefined` |
 
 ## Eventos
 
 `<Tabs ... on:event="..."/>`
 
-| Eventos     | Disparado quando ...           | Tipo        |
-|-------------|--------------------------------|-------------|
-| change      | Especifique uma função que será chamada quando trocar de aba. Recebe índice atual e antigo.  |`function({ currentIndex, lastIndex })` |
+| Eventos | Disparado quando ...                                                                        | Tipo                                    |
+| ------- | ------------------------------------------------------------------------------------------- | --------------------------------------- |
+| change  | Especifique uma função que será chamada quando trocar de aba. Recebe índice atual e antigo. | `function({ currentIndex, lastIndex })` |

--- a/packages/components/Tabs/TabPane.html
+++ b/packages/components/Tabs/TabPane.html
@@ -1,3 +1,3 @@
-<div class="tab-pane" title="{title}" hidden="{true}">
+<div class="tab-pane" title="{title}" hidden="{true}" data-route="{route}">
   <slot></slot>
 </div>

--- a/packages/components/Tabs/Tabs.html
+++ b/packages/components/Tabs/Tabs.html
@@ -3,7 +3,7 @@
   <table class="tab-navigation">
     <tr>
       {#each _tabs as tab, key}
-      <td on:click="set({index: key})" class:active="key === index">
+      <td on:click="_selectTab(key)" class:active="key === index">
         {tab.title}
         <div class="line"></div>
       </td>
@@ -19,45 +19,111 @@
 </div>
 
 <script>
+  const CHANGEON = {
+    STATE: 'state',
+    ROUTER: 'route',
+  };
+
   export default {
     data() {
       return {
         _tabs: [],
         _lastIndex: 0,
+        _routes: [],
         index: 0,
+        changeOn: CHANGEON.STATE,
+        CHANGEON,
       };
     },
     oncreate() {
       const _tabs = [].filter.call(
         this.refs.container.children,
         element =>
-          element.classList.contains('tab-pane') && element.title !== 'undefined',
+          element.classList.contains('tab-pane') &&
+          element.title !== 'undefined',
       );
 
       this.set({ _tabs });
-    },
-    onupdate({ changed, current }) {
-      if (changed.index || changed._tabs) {
-        // Update tab position
-        this._changeTab(current.index);
+
+      const { changeOn } = this.get();
+
+      if (changeOn === CHANGEON.ROUTER && this.root.router) {
+        const _routes = _tabs.map(tab => tab.getAttribute('data-route'));
+        const { pageInstance } = this.root.router;
+        if (pageInstance && pageInstance.current && _routes.length) {
+          const index = _routes.indexOf(pageInstance.current);
+          if (index > -1) {
+            this.set({ index });
+          }
+        }
+        this.set({ _routes });
       }
+
+      this.on('update', this._stateUpdate);
     },
     methods: {
       _validIndex(index) {
         const { _tabs } = this.get();
-        if (index < 0) return 0;
+        if (!index || index < 0) return 0;
         if (index >= _tabs.length) return _tabs.length - 1;
         return index;
       },
-      _changeTab(index) {
-        const { _tabs: _tabElements, _lastIndex: lastIndex } = this.get();
-        if (_tabElements.length) {
-          _tabElements[lastIndex].hidden = true;
+      _selectTab(key) {
+        const { changeOn } = this.get();
+        if (changeOn === CHANGEON.ROUTER) {
+          this._changeTab(key, true);
+        } else {
+          this.set({ index: key });
+        }
+      },
+      _changeTab(rawIndex, useRouter = false) {
+        const { _tabs, _routes, _lastIndex } = this.get();
+        if (_tabs.length) {
+          const index = this._validIndex(rawIndex);
+          const route = _routes[index];
+          const props = {
+            index,
+            _lastIndex,
+          };
 
-          const currentIdx = this._validIndex(index);
-          _tabElements[currentIdx].hidden = false;
-          this.set({ index: currentIdx, _lastIndex: currentIdx });
-          this.fire('change', { index: currentIdx, lastIndex });
+          const { router } = this.root;
+
+          if (useRouter && router && typeof route === 'string') {
+            const {
+              context: { page, title, state },
+            } = router.get();
+
+            // Change router without push the history
+            state.path = route;
+            window.history.replaceState(
+              { ...state, ...props },
+              title,
+              page._hashbang && this.path !== '/' ? `#!${route}` : route,
+            );
+          }
+
+          this._showContentOf(props);
+        }
+      },
+      _showContentOf({ index, _lastIndex }) {
+        const { _tabs } = this.get();
+        if (_lastIndex !== index) _tabs[_lastIndex].hidden = true;
+        _tabs[index].hidden = false;
+        this.set({ index, _lastIndex: index });
+        this.fire('change', { index, _lastIndex });
+      },
+      _stateUpdate({ changed, current }) {
+        if (changed.index || changed._tabs) {
+          // Update tab position
+          if (
+            current.changeOn === CHANGEON.ROUTER &&
+            current.index &&
+            current._lastIndex
+          ) {
+            this._showContentOf(current);
+          } else {
+            this._changeTab(current.index, false);
+          }
         }
       },
     },

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -7,10 +7,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "test": "jest",
-    "start": "rollup -c ../../../tools/rollup/config.component.watch.js -w"
-  },
   "devDependencies": {
     "@mamba/button": "^2.8.2",
     "@mamba/collection": "^2.8.2",


### PR DESCRIPTION
Using the `route` operating mode of the` changeOn` parameter causes the flaps to be changed by the route of the application. This is useful for remembering the position of the tab index for internal routes, and back in the browser history, or for when you want to enter a page displaying a specific index.