### PR TITLE
fix: 🐛 prevent shortcut and keystroke propagate event to other pages

### DIFF
--- a/packages/components/App/App.html
+++ b/packages/components/App/App.html
@@ -296,7 +296,10 @@
          * If a shortcut element was found.
          * If 'enter' was clicked, check if the shortcut element isn't already focused
          */
-        if (keyName !== 'enter' || document.activeElement !== shortcutEl) {
+        if (
+          shortcutEl && shortcutEl === e.target &&
+          (keyName !== 'enter' || document.activeElement !== shortcutEl)
+        ) {
           /**
            * Adapted from:
            * https://stackoverflow.com/questions/15739263/phantomjs-click-an-element


### PR DESCRIPTION
Conserta bug na SDK onde os eventos de Keystroke e Shortcut de uma página estão sendo propagados para o contexto de outra página.

VSTS: [97733](https://stonepagamentos.visualstudio.com/POS%20-%20Mamba/_workitems/edit/97733)