### PR TITLE
fix: 🐛 Fixed print bug

### DIFF
--- a/packages/components/Printable/Printable.html
+++ b/packages/components/Printable/Printable.html
@@ -24,7 +24,7 @@
       <h1 class="title-dialog">ERRO NA IMPRESSÃO</h1>
       <!-- showInfoPrinter works independent of payment app -->
       <!-- You can use whenever you want if the app makes sense to show this info -->
-      {#if showInfoPrinter || ($transactionType && !$config.isPreAuth)}
+      {#if (showInfoPrinter && id) || ($transactionType && !$config.isPreAuth)}
         <p class="failure-dialog-txt">
           A filipeta ainda está disponível no app <strong>Reimpressão</strong>.
         </p>

--- a/packages/components/Printable/Printable.html
+++ b/packages/components/Printable/Printable.html
@@ -22,12 +22,13 @@
   >
       <img class="failure-dialog-icon" src={alertIcon} alt="" />
       <h1 class="title-dialog">ERRO NA IMPRESSÃO</h1>
-        <!-- *** Shows when is Payment AND is not PreAuth ***  -->
-        {#if $transactionType && !$config.isPreAuth}
-          <p class="failure-dialog-txt">
-            A filipeta ainda está disponível no app <strong>Reimpressão</strong>.
-          </p>
-        {/if}
+      <!-- showInfoPrinter works independent of payment app -->
+      <!-- You can use whenever you want if the app makes sense to show this info -->
+      {#if showInfoPrinter || ($transactionType && !$config.isPreAuth)}
+        <p class="failure-dialog-txt">
+          A filipeta ainda está disponível no app <strong>Reimpressão</strong>.
+        </p>
+      {/if}
   </Dialog>
 {/if}
 
@@ -61,6 +62,7 @@
         showPrintingDialog: true,
         dithering: false,
         id: null,
+        showInfoPrinter: false,
       };
     },
     onupdate({ changed, current }) {

--- a/packages/components/Printable/package-lock.json
+++ b/packages/components/Printable/package-lock.json
@@ -5,26 +5,43 @@
   "requires": true,
   "dependencies": {
     "@mamba/dialog": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@mamba/dialog/-/dialog-2.26.0.tgz",
-      "integrity": "sha512-wKdtNZ7CiKKXjZ/ZOAR+FEAUtiCiSdwPmFlgg1aFphJf3llZKnfNMpccZwc3fM6e9OOE8YoZXSnxmTIQflmvQQ==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/@mamba/dialog/-/dialog-2.27.1.tgz",
+      "integrity": "sha512-mOh/Ke3xo9P7qzMjIbMD//UxosgoqIhRjvPIhzQMJepV6vOVHKyy0+21UPFvWI4NfQfxOnb8Q2dthgy60sTyzg==",
       "requires": {
-        "@mamba/icon": "^2.26.0",
-        "@mamba/styles": "^2.26.0"
+        "@mamba/icon": "2.27.1",
+        "@mamba/styles": "2.27.1"
+      },
+      "dependencies": {
+        "@mamba/icon": {
+          "version": "2.27.1",
+          "resolved": "https://registry.npmjs.org/@mamba/icon/-/icon-2.27.1.tgz",
+          "integrity": "sha512-LfXb4q/i1bRvraC+fYnWdnfelf4/Nl8jTa/hershLnzOwNyCS88AFgBM2RXCeYDHXDTnwQfgcMzVGzDbOWVfyg==",
+          "requires": {
+            "@mamba/styles": "2.27.1"
+          }
+        },
+        "@mamba/styles": {
+          "version": "2.27.1",
+          "resolved": "https://registry.npmjs.org/@mamba/styles/-/styles-2.27.1.tgz",
+          "integrity": "sha512-iqDmyq8kp3Ynor2bqMTBheaE15sdA2amrKHjGHeqA2ODdpVLH0h+xcutjlqawBvC/1VvojPNWYX/FdQz79DGIw=="
+        }
       }
     },
     "@mamba/icon": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@mamba/icon/-/icon-2.26.0.tgz",
-      "integrity": "sha512-8of4Zk9ofJlXWlRF9oSHsyH1G/IXavg1y2sRgEK/68OBt/Aag2JA7Fs2kp6S/ghOmmi/sgozF/dntH6VfF/PMw==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/@mamba/icon/-/icon-2.27.1.tgz",
+      "integrity": "sha512-LfXb4q/i1bRvraC+fYnWdnfelf4/Nl8jTa/hershLnzOwNyCS88AFgBM2RXCeYDHXDTnwQfgcMzVGzDbOWVfyg==",
+      "dev": true,
       "requires": {
-        "@mamba/styles": "^2.26.0"
+        "@mamba/styles": "2.27.1"
       }
     },
     "@mamba/styles": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@mamba/styles/-/styles-2.26.0.tgz",
-      "integrity": "sha512-3g41v33Fot3KMPQ2Y+XsHy1mPOFSS6bTqYsZQzuGTQPJNSH7oblj3t2+REnOZNfN2zeTZ2DaNYYffVia/2ZnfA=="
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/@mamba/styles/-/styles-2.27.1.tgz",
+      "integrity": "sha512-iqDmyq8kp3Ynor2bqMTBheaE15sdA2amrKHjGHeqA2ODdpVLH0h+xcutjlqawBvC/1VvojPNWYX/FdQz79DGIw==",
+      "dev": true
     }
   }
 }


### PR DESCRIPTION
I included a new state to show the information when the printer was a break because just exists one rule that checks whether there is a store state called transactionType or pre auth is not enabled.

With that, we can use this information on all apps that make sense to show it.