### PR TITLE
feat: 🎸 enable customizable printable error message

### DIFF
--- a/packages/components/Printable/Printable.html
+++ b/packages/components/Printable/Printable.html
@@ -26,7 +26,7 @@
       <!-- You can use whenever you want if the app makes sense to show this info -->
       {#if (showInfoPrinter && id) || ($transactionType && !$config.isPreAuth)}
         <p class="failure-dialog-txt">
-          A filipeta ainda está disponível no app <strong>Reimpressão</strong>.
+          <slot name="error-message">A filipeta ainda está disponível no app <strong>Reimpressão</strong>.</slot>
         </p>
       {:elseif showNoPaperErrorMessage}
         <p class="failure-dialog-txt">


### PR DESCRIPTION
Adição de um slot na mensagem de erro do objeto Printable, o que permite alterar a mensagem padrão.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- Set the Jira issue number on the link -->

[WEBSDK-XXXX](https://stonepayments.atlassian.net/browse/WEBSDK-XXXX)

<!-- Describe the big picture of your changes here -->

## Motivation and Context
Torna a mensagem customizável - a mensagem padrão atual não é aplicável ao caso do Ton, por exemplo, que usa um app "Recibos" ao invés de "Reimpressão".
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Describe in detail how you tested your changes -->

## Screenshots (if appropriate):
<!-- Add screenshots here, if appropriate -->

## Further Comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
