### PR TITLE
Make semantic version locks more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "scripts": {
     "lint": "npm run lint:css; npm run lint:js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/cli@4.0.0...@mamba/cli@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/cli
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/cli@3.4.2...@mamba/cli@4.0.0) (2022-07-21)
 
 **Note:** Version bump only for package @mamba/cli

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/cli@4.0.1...@mamba/cli@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/cli
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/cli@4.0.0...@mamba/cli@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/cli",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Mamba CLI",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Mamba CLI",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/App/CHANGELOG.md
+++ b/packages/components/App/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/app@5.0.1...@mamba/app@5.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/app
+
+
+
+
+
 ### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/app@5.0.0...@mamba/app@5.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/app

--- a/packages/components/App/CHANGELOG.md
+++ b/packages/components/App/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/app@5.0.0...@mamba/app@5.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/app
+
+
+
+
+
 ## [5.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/app@3.9.3...@mamba/app@5.0.0) (2022-07-21)
 
 

--- a/packages/components/App/package.json
+++ b/packages/components/App/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/app",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "svelte": "App.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/App/package.json
+++ b/packages/components/App/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/app",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "svelte": "App.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/App/package.json
+++ b/packages/components/App/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
@@ -14,9 +14,9 @@
   "peerDependencies": {
     "@mamba/button": "*",
     "@mamba/keyboard": "*",
-    "@mamba/pos": ">=4",
-    "@mamba/styles": ">=4",
-    "@mamba/utils": ">=4"
+    "@mamba/pos": ">=3",
+    "@mamba/styles": ">=3",
+    "@mamba/utils": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/AppBar/CHANGELOG.md
+++ b/packages/components/AppBar/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/appbar@4.0.1...@mamba/appbar@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/appbar
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/appbar@4.0.0...@mamba/appbar@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/appbar

--- a/packages/components/AppBar/CHANGELOG.md
+++ b/packages/components/AppBar/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/appbar@4.0.0...@mamba/appbar@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/appbar
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/appbar@3.5.8...@mamba/appbar@4.0.0) (2022-07-21)
 
 

--- a/packages/components/AppBar/package.json
+++ b/packages/components/AppBar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/appbar",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "AppBar.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/AppBar/package.json
+++ b/packages/components/AppBar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/appbar",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "AppBar.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/AppBar/package.json
+++ b/packages/components/AppBar/package.json
@@ -6,14 +6,14 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@mamba/icon": ">=4",
-    "@mamba/styles": ">=4",
+    "@mamba/icon": ">=3",
+    "@mamba/styles": ">=3",
     "svelte": "<3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"

--- a/packages/components/Barcode/CHANGELOG.md
+++ b/packages/components/Barcode/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/barcode@4.0.1...@mamba/barcode@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/barcode
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/barcode@4.0.0...@mamba/barcode@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/barcode

--- a/packages/components/Barcode/CHANGELOG.md
+++ b/packages/components/Barcode/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/barcode@4.0.0...@mamba/barcode@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/barcode
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/barcode@3.5.7...@mamba/barcode@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Barcode/package.json
+++ b/packages/components/Barcode/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Barcode/package.json
+++ b/packages/components/Barcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/barcode",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Barcode.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Barcode/package.json
+++ b/packages/components/Barcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/barcode",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Barcode.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Brands/CHANGELOG.md
+++ b/packages/components/Brands/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/brands@4.0.0...@mamba/brands@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/brands
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/brands@3.5.7...@mamba/brands@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Brands/CHANGELOG.md
+++ b/packages/components/Brands/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/brands@4.0.1...@mamba/brands@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/brands
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/brands@4.0.0...@mamba/brands@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/brands

--- a/packages/components/Brands/package.json
+++ b/packages/components/Brands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/brands",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Brands.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Brands/package.json
+++ b/packages/components/Brands/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Brands/package.json
+++ b/packages/components/Brands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/brands",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Brands.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Button/CHANGELOG.md
+++ b/packages/components/Button/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/button@5.0.0...@mamba/button@5.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/button
+
+
+
+
+
 ## [5.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/button@3.5.8...@mamba/button@5.0.0) (2022-07-21)
 
 

--- a/packages/components/Button/CHANGELOG.md
+++ b/packages/components/Button/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/button@5.0.1...@mamba/button@5.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/button
+
+
+
+
+
 ### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/button@5.0.0...@mamba/button@5.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/button

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/button",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "svelte": "Button.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -54,7 +54,7 @@
     }
   ],
   "devDependencies": {
-    "@mamba/icon": ">=4"
+    "@mamba/icon": "4.0.1"
   },
   "peerDependencies": {
     "@mamba/styles": ">=4"

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/button",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "svelte": "Button.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -54,7 +54,7 @@
     }
   ],
   "devDependencies": {
-    "@mamba/icon": "4.0.1"
+    "@mamba/icon": "4.0.2"
   },
   "peerDependencies": {
     "@mamba/styles": ">=3"

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
@@ -57,7 +57,7 @@
     "@mamba/icon": "4.0.1"
   },
   "peerDependencies": {
-    "@mamba/styles": ">=4"
+    "@mamba/styles": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Carousel/CHANGELOG.md
+++ b/packages/components/Carousel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/carousel@4.0.1...@mamba/carousel@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/carousel
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/carousel@4.0.0...@mamba/carousel@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/carousel

--- a/packages/components/Carousel/CHANGELOG.md
+++ b/packages/components/Carousel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/carousel@4.0.0...@mamba/carousel@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/carousel
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/carousel@3.5.7...@mamba/carousel@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Carousel/package.json
+++ b/packages/components/Carousel/package.json
@@ -6,14 +6,14 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@mamba/icon": ">=4",
-    "@mamba/styles": ">=4"
+    "@mamba/icon": ">=3",
+    "@mamba/styles": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Carousel/package.json
+++ b/packages/components/Carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/carousel",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Carousel.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Carousel/package.json
+++ b/packages/components/Carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/carousel",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Carousel.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Collection/CHANGELOG.md
+++ b/packages/components/Collection/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/collection@4.0.0...@mamba/collection@4.0.1) (2022-08-09)
+
+
+### Bug Fixes
+
+* add gitHead hash ([47a9d1a](https://github.com/stone-payments/pos-mamba-sdk/commit/47a9d1a233cc859a4230ef98573bc7152d918e46))
+* fix import ([282a154](https://github.com/stone-payments/pos-mamba-sdk/commit/282a154931e375bce254046f84a9efb32dac5a3c))
+* fix import ([#800](https://github.com/stone-payments/pos-mamba-sdk/issues/800)) ([47add09](https://github.com/stone-payments/pos-mamba-sdk/commit/47add092264ca8af5e733db54233ce2b55f3d6bf))
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/collection@3.5.7...@mamba/collection@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Collection/CHANGELOG.md
+++ b/packages/components/Collection/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/collection@4.0.1...@mamba/collection@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/collection
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/collection@4.0.0...@mamba/collection@4.0.1) (2022-08-09)
 
 

--- a/packages/components/Collection/package.json
+++ b/packages/components/Collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/collection",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Collection.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mamba/styles": "4.0.1",
-    "@mamba/switch": "5.0.1"
+    "@mamba/styles": "4.0.2",
+    "@mamba/switch": "5.0.2"
   },
   "peerDependencies": {
     "@mamba/icon": ">=3"

--- a/packages/components/Collection/package.json
+++ b/packages/components/Collection/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
@@ -16,7 +16,7 @@
     "@mamba/switch": "5.0.1"
   },
   "peerDependencies": {
-    "@mamba/icon": ">=4"
+    "@mamba/icon": ">=3"
   },
   "gitHead": "798929523737000b8c07303e9c66feff5a8b9340"
 }

--- a/packages/components/Collection/package.json
+++ b/packages/components/Collection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/collection",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Collection.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mamba/styles": ">=4",
-    "@mamba/switch": "5.0.0"
+    "@mamba/styles": "4.0.1",
+    "@mamba/switch": "5.0.1"
   },
   "peerDependencies": {
     "@mamba/icon": ">=4"

--- a/packages/components/Container/CHANGELOG.md
+++ b/packages/components/Container/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/container@4.0.0...@mamba/container@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/container
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/container@3.5.7...@mamba/container@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Container/CHANGELOG.md
+++ b/packages/components/Container/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/container@4.0.1...@mamba/container@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/container
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/container@4.0.0...@mamba/container@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/container

--- a/packages/components/Container/package.json
+++ b/packages/components/Container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/container",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Container.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Container/package.json
+++ b/packages/components/Container/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Container/package.json
+++ b/packages/components/Container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/container",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Container.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Dialog/CHANGELOG.md
+++ b/packages/components/Dialog/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/dialog@4.0.0...@mamba/dialog@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/dialog
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/dialog@3.5.8...@mamba/dialog@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Dialog/CHANGELOG.md
+++ b/packages/components/Dialog/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/dialog@4.0.1...@mamba/dialog@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/dialog
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/dialog@4.0.0...@mamba/dialog@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/dialog

--- a/packages/components/Dialog/package.json
+++ b/packages/components/Dialog/package.json
@@ -6,14 +6,14 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@mamba/icon": ">=4",
-    "@mamba/styles": ">=4"
+    "@mamba/icon": ">=3",
+    "@mamba/styles": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Dialog/package.json
+++ b/packages/components/Dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/dialog",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Dialog.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Dialog/package.json
+++ b/packages/components/Dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/dialog",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Dialog.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Flatlist/CHANGELOG.md
+++ b/packages/components/Flatlist/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/flatlist@6.0.0...@mamba/flatlist@6.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/flatlist
+
+
+
+
+
 ## [6.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/flatlist@4.3.3...@mamba/flatlist@6.0.0) (2022-07-21)
 
 

--- a/packages/components/Flatlist/CHANGELOG.md
+++ b/packages/components/Flatlist/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/flatlist@6.0.1...@mamba/flatlist@6.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/flatlist
+
+
+
+
+
 ### [6.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/flatlist@6.0.0...@mamba/flatlist@6.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/flatlist

--- a/packages/components/Flatlist/package.json
+++ b/packages/components/Flatlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/flatlist",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "svelte": "Flatlist.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Flatlist/package.json
+++ b/packages/components/Flatlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/flatlist",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "svelte": "Flatlist.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Flatlist/package.json
+++ b/packages/components/Flatlist/package.json
@@ -8,16 +8,16 @@
   "main": "index.js",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
     "@mamba/core": "*",
-    "@mamba/icon": ">=4",
-    "@mamba/styles": ">=4",
-    "@mamba/utils": ">=4"
+    "@mamba/icon": ">=3",
+    "@mamba/styles": ">=3",
+    "@mamba/utils": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Icon/CHANGELOG.md
+++ b/packages/components/Icon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/icon@4.0.1...@mamba/icon@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/icon
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/icon@4.0.0...@mamba/icon@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/icon

--- a/packages/components/Icon/CHANGELOG.md
+++ b/packages/components/Icon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/icon@4.0.0...@mamba/icon@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/icon
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/icon@3.5.7...@mamba/icon@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/icon",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Icon.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/icon",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Icon.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -6,13 +6,13 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db",
   "peerDependencies": {
-    "@mamba/styles": ">=4"
+    "@mamba/styles": ">=3"
   }
 }

--- a/packages/components/Input/CHANGELOG.md
+++ b/packages/components/Input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/input@6.0.1...@mamba/input@6.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/input
+
+
+
+
+
 ### [6.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/input@6.0.0...@mamba/input@6.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/input

--- a/packages/components/Input/CHANGELOG.md
+++ b/packages/components/Input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/input@6.0.0...@mamba/input@6.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/input
+
+
+
+
+
 ## [6.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/input@4.1.3...@mamba/input@6.0.0) (2022-07-21)
 
 

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
@@ -16,10 +16,10 @@
   },
   "peerDependencies": {
     "@mamba/core": "*",
-    "@mamba/icon": ">=4",
+    "@mamba/icon": ">=3",
     "@mamba/keyboard": "*",
-    "@mamba/pos": ">=4",
-    "@mamba/utils": ">=4"
+    "@mamba/pos": ">=3",
+    "@mamba/utils": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/input",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "svelte": "Input.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mamba/styles": ">=4"
+    "@mamba/styles": "4.0.1"
   },
   "peerDependencies": {
     "@mamba/core": "*",

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/input",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "svelte": "Input.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mamba/styles": "4.0.1"
+    "@mamba/styles": "4.0.2"
   },
   "peerDependencies": {
     "@mamba/core": "*",

--- a/packages/components/Keyboard/CHANGELOG.md
+++ b/packages/components/Keyboard/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.3](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/keyboard@1.0.2...@mamba/keyboard@1.0.3) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/keyboard
+
+
+
+
+
 ### [1.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/keyboard@1.0.0...@mamba/keyboard@1.0.2) (2022-08-09)
 
 

--- a/packages/components/Keyboard/CHANGELOG.md
+++ b/packages/components/Keyboard/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/keyboard@1.0.0...@mamba/keyboard@1.0.2) (2022-08-09)
+
+
+### Bug Fixes
+
+* add gitHead hash ([47a9d1a](https://github.com/stone-payments/pos-mamba-sdk/commit/47a9d1a233cc859a4230ef98573bc7152d918e46))
+
+
+
 ## 1.0.0 (2022-07-21)
 
 

--- a/packages/components/Keyboard/package.json
+++ b/packages/components/Keyboard/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "files": [
     "*",
@@ -33,8 +33,8 @@
   },
   "peerDependencies": {
     "@mamba/core": "*",
-    "@mamba/input": ">=4",
-    "@mamba/utils": ">=4"
+    "@mamba/input": ">=3",
+    "@mamba/utils": ">=3"
   },
   "gitHead": "798929523737000b8c07303e9c66feff5a8b9340"
 }

--- a/packages/components/Keyboard/package.json
+++ b/packages/components/Keyboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/keyboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "svelte": "Keyboard.html",

--- a/packages/components/Keyboard/package.json
+++ b/packages/components/Keyboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/keyboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "svelte": "Keyboard.html",

--- a/packages/components/Printable/CHANGELOG.md
+++ b/packages/components/Printable/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/printable@5.0.0...@mamba/printable@5.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/printable
+
+
+
+
+
 ## [5.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/printable@3.6.4...@mamba/printable@5.0.0) (2022-07-21)
 
 

--- a/packages/components/Printable/CHANGELOG.md
+++ b/packages/components/Printable/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/printable@5.0.1...@mamba/printable@5.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/printable
+
+
+
+
+
 ### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/printable@5.0.0...@mamba/printable@5.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/printable

--- a/packages/components/Printable/package.json
+++ b/packages/components/Printable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/printable",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "svelte": "Printable.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Printable/package.json
+++ b/packages/components/Printable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/printable",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "svelte": "Printable.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Printable/package.json
+++ b/packages/components/Printable/package.json
@@ -6,14 +6,14 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@mamba/dialog": ">=4",
-    "@mamba/pos": ">=4"
+    "@mamba/dialog": ">=3",
+    "@mamba/pos": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Progress/CHANGELOG.md
+++ b/packages/components/Progress/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/progress@4.0.1...@mamba/progress@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/progress
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/progress@4.0.0...@mamba/progress@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/progress

--- a/packages/components/Progress/CHANGELOG.md
+++ b/packages/components/Progress/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/progress@4.0.0...@mamba/progress@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/progress
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/progress@3.5.7...@mamba/progress@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Progress/package.json
+++ b/packages/components/Progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/progress",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "ProgressBar.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Progress/package.json
+++ b/packages/components/Progress/package.json
@@ -6,13 +6,13 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@mamba/styles": ">=4"
+    "@mamba/styles": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Progress/package.json
+++ b/packages/components/Progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/progress",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "ProgressBar.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/QRCode/CHANGELOG.md
+++ b/packages/components/QRCode/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/qrcode@4.0.0...@mamba/qrcode@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/qrcode
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/qrcode@3.5.7...@mamba/qrcode@4.0.0) (2022-07-21)
 
 

--- a/packages/components/QRCode/CHANGELOG.md
+++ b/packages/components/QRCode/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/qrcode@4.0.1...@mamba/qrcode@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/qrcode
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/qrcode@4.0.0...@mamba/qrcode@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/qrcode

--- a/packages/components/QRCode/package.json
+++ b/packages/components/QRCode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/qrcode",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "QRCode.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/QRCode/package.json
+++ b/packages/components/QRCode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/qrcode",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "QRCode.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/QRCode/package.json
+++ b/packages/components/QRCode/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
@@ -15,7 +15,7 @@
     "qrious": "^4.0.2"
   },
   "peerDependencies": {
-    "@mamba/styles": ">=4"
+    "@mamba/styles": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Radio/CHANGELOG.md
+++ b/packages/components/Radio/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/radio@4.0.1...@mamba/radio@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/radio
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/radio@4.0.0...@mamba/radio@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/radio

--- a/packages/components/Radio/CHANGELOG.md
+++ b/packages/components/Radio/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/radio@4.0.0...@mamba/radio@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/radio
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/radio@3.5.7...@mamba/radio@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Radio/package.json
+++ b/packages/components/Radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/radio",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Radio.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Radio/package.json
+++ b/packages/components/Radio/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Radio/package.json
+++ b/packages/components/Radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/radio",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Radio.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Range/CHANGELOG.md
+++ b/packages/components/Range/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/range@5.0.0...@mamba/range@5.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/range
+
+
+
+
+
 ## [5.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/range@3.5.7...@mamba/range@5.0.0) (2022-07-21)
 
 

--- a/packages/components/Range/CHANGELOG.md
+++ b/packages/components/Range/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/range@5.0.1...@mamba/range@5.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/range
+
+
+
+
+
 ### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/range@5.0.0...@mamba/range@5.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/range

--- a/packages/components/Range/package.json
+++ b/packages/components/Range/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/range",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "svelte": "Range.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Range/package.json
+++ b/packages/components/Range/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/range",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "svelte": "Range.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Range/package.json
+++ b/packages/components/Range/package.json
@@ -6,13 +6,13 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
   },
   "peerDependencies": {
-    "@mamba/styles": ">=4"
+    "@mamba/styles": ">=3"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Sprite/CHANGELOG.md
+++ b/packages/components/Sprite/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/sprite@4.0.0...@mamba/sprite@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/sprite
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/sprite@3.5.7...@mamba/sprite@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Sprite/CHANGELOG.md
+++ b/packages/components/Sprite/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/sprite@4.0.1...@mamba/sprite@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/sprite
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/sprite@4.0.0...@mamba/sprite@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/sprite

--- a/packages/components/Sprite/package.json
+++ b/packages/components/Sprite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/sprite",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Sprite.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Sprite/package.json
+++ b/packages/components/Sprite/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Sprite/package.json
+++ b/packages/components/Sprite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/sprite",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Sprite.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Switch/CHANGELOG.md
+++ b/packages/components/Switch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/switch@5.0.1...@mamba/switch@5.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/switch
+
+
+
+
+
 ### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/switch@5.0.0...@mamba/switch@5.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/switch

--- a/packages/components/Switch/CHANGELOG.md
+++ b/packages/components/Switch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/switch@5.0.0...@mamba/switch@5.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/switch
+
+
+
+
+
 ## [5.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/switch@3.5.7...@mamba/switch@5.0.0) (2022-07-21)
 
 

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/switch",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "svelte": "Switch.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/switch",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "svelte": "Switch.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Tabs/CHANGELOG.md
+++ b/packages/components/Tabs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/tabs@4.0.1...@mamba/tabs@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/tabs
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/tabs@4.0.0...@mamba/tabs@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/tabs

--- a/packages/components/Tabs/CHANGELOG.md
+++ b/packages/components/Tabs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/tabs@4.0.0...@mamba/tabs@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/tabs
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/tabs@3.5.7...@mamba/tabs@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/tabs",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Tabs.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mamba/collection": "4.0.1"
+    "@mamba/collection": "4.0.2"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/tabs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Tabs.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mamba/collection": ">=4"
+    "@mamba/collection": "4.0.1"
   },
   "gitHead": "ddc05702292f5dea2772130436f0a00fbd5be1db"
 }

--- a/packages/components/Toast/CHANGELOG.md
+++ b/packages/components/Toast/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/toast@4.0.1...@mamba/toast@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/toast
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/toast@4.0.0...@mamba/toast@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/toast

--- a/packages/components/Toast/CHANGELOG.md
+++ b/packages/components/Toast/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/toast@4.0.0...@mamba/toast@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/toast
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/toast@3.5.7...@mamba/toast@4.0.0) (2022-07-21)
 
 

--- a/packages/components/Toast/package.json
+++ b/packages/components/Toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/toast",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "svelte": "Toast.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/components/Toast/package.json
+++ b/packages/components/Toast/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/Toast/package.json
+++ b/packages/components/Toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/toast",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "svelte": "Toast.html",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/configs/CHANGELOG.md
+++ b/packages/configs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/configs@4.0.0...@mamba/configs@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/configs
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/configs@3.5.7...@mamba/configs@4.0.0) (2022-07-21)
 
 

--- a/packages/configs/CHANGELOG.md
+++ b/packages/configs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/configs@4.0.1...@mamba/configs@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/configs
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/configs@4.0.0...@mamba/configs@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/configs

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/configs",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Tooling config presets to use in mamba projects.",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/configs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Tooling config presets to use in mamba projects.",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.1.0 (2022-08-09)
+
+
+### Features
+
+* 🎸 add core files ([63a8e96](https://github.com/stone-payments/pos-mamba-sdk/commit/63a8e96d5f280ff84fd267c713b82cbc84099e79))
+* 🎸 initiate @mamba/core package ([df66b79](https://github.com/stone-payments/pos-mamba-sdk/commit/df66b795dd0e85b5754c2f8236d7fb9a198b2d25))
+* new mamba keyboard implementation ([23466f2](https://github.com/stone-payments/pos-mamba-sdk/commit/23466f28fbd58067248b308218d4eb91b8889160))

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/core@1.1.0...@mamba/core@1.1.1) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/core
+
+
+
+
+
 ## 1.1.0 (2022-08-09)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "description": "Mamba QT bindings, wrappers and embbebded hardware handlers",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "description": "Mamba QT bindings, wrappers and embbebded hardware handlers",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/logger@4.0.1...@mamba/logger@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/logger
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/logger@4.0.0...@mamba/logger@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/logger

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/logger@4.0.0...@mamba/logger@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/logger
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/logger@3.5.6...@mamba/logger@4.0.0) (2022-07-21)
 
 **Note:** Version bump only for package @mamba/logger

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/logger",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "module": "index.js",
   "main": "index.js",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/logger",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/pos/CHANGELOG.md
+++ b/packages/pos/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/pos@4.0.0...@mamba/pos@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/pos
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/pos@3.13.3...@mamba/pos@4.0.0) (2022-07-21)
 
 

--- a/packages/pos/CHANGELOG.md
+++ b/packages/pos/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/pos@4.0.1...@mamba/pos@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/pos
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/pos@4.0.0...@mamba/pos@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/pos

--- a/packages/pos/package.json
+++ b/packages/pos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/pos",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Mamba web environment wrapper and simulator",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/pos/package.json
+++ b/packages/pos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/pos",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Mamba web environment wrapper and simulator",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/pos/package.json
+++ b/packages/pos/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"
@@ -17,16 +17,16 @@
     "svelte": "<3"
   },
   "peerDependencies": {
-    "@mamba/app": ">=4",
-    "@mamba/button": ">=4",
+    "@mamba/app": ">=3",
+    "@mamba/button": ">=3",
     "@mamba/core": "*",
-    "@mamba/dialog": ">=4",
-    "@mamba/icon": ">=4",
+    "@mamba/dialog": ">=3",
+    "@mamba/icon": ">=3",
     "@mamba/keyboard": "*",
-    "@mamba/radio": ">=4",
-    "@mamba/sprite": ">=4",
-    "@mamba/switch": ">=4",
-    "@mamba/utils": ">=4"
+    "@mamba/radio": ">=3",
+    "@mamba/sprite": ">=3",
+    "@mamba/switch": ">=3",
+    "@mamba/utils": ">=3"
   },
   "gitHead": "78978116d5c790c51aaf9af9db47ea8beaa4726b"
 }

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/styles@4.0.1...@mamba/styles@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/styles
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/styles@4.0.0...@mamba/styles@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/styles

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/styles@4.0.0...@mamba/styles@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/styles
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/styles@3.5.7...@mamba/styles@4.0.0) (2022-07-21)
 
 

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/styles",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Mamba core and reset styles",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/styles",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Mamba core and reset styles",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/utils@5.0.0...@mamba/utils@5.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/utils
+
+
+
+
+
 ## [5.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/utils@4.2.2...@mamba/utils@5.0.0) (2022-07-21)
 
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/utils@5.0.1...@mamba/utils@5.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/utils
+
+
+
+
+
 ### [5.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/utils@5.0.0...@mamba/utils@5.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/utils

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": ">=6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/utils",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Utility methods for mamba apps",
   "module": "index.js",
   "sideEffects": false,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/utils",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Utility methods for mamba apps",
   "module": "index.js",
   "sideEffects": false,

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/webpack@4.0.0...@mamba/webpack@4.0.1) (2022-08-09)
+
+**Note:** Version bump only for package @mamba/webpack
+
+
+
+
+
 ## [4.0.0](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/webpack@3.7.3...@mamba/webpack@4.0.0) (2022-07-21)
 
 

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.2](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/webpack@4.0.1...@mamba/webpack@4.0.2) (2022-08-30)
+
+**Note:** Version bump only for package @mamba/webpack
+
+
+
+
+
 ### [4.0.1](https://github.com/stone-payments/pos-mamba-sdk/compare/@mamba/webpack@4.0.0...@mamba/webpack@4.0.1) (2022-08-09)
 
 **Note:** Version bump only for package @mamba/webpack

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/webpack",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Webpack configs for Mamba Applications",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -9,10 +9,10 @@
   },
   "engines": {
     "node": ">= 8 || <= 14",
-    "npm": "^7 || ^8"
+    "npm": "^6 || ^7 || ^8"
   },
   "peerDependencies": {
-    "@mamba/configs": ">=4"
+    "@mamba/configs": ">=3"
   },
   "dependencies": {
     "babel-loader": "^8.0.4",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mamba/webpack",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Webpack configs for Mamba Applications",
   "author": "Stone Payments - Mamba Team",
   "license": "Apache-2.0",


### PR DESCRIPTION
Drop 1 required version  of peer dependencies for npm 7/8 users.