### PR TITLE
Revert from before wrong sdk pre-publish

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6085,7 +6085,7 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-loader@^4.0.2:
+eslint-loader@^4.0.0, eslint-loader@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-4.0.2.tgz#386a1e21bcb613b3cf2d252a3b708023ccfb41ec"
   integrity sha512-EDpXor6lsjtTzZpLUn7KmXs02+nIjGcgees9BYjNkWra3jVq5vVa8IoCKgzT2M7dNNeoMBtaSG83Bd40N3poLw==


### PR DESCRIPTION
This reverts commit 4a2525c5872b8fca90c188e3ded6ccb4d0dd3f58.