### PR TITLE
Fix/utils v5.3.0

### DIFF
--- a/packages/pos/simulator/view/pos/panels/POS.html
+++ b/packages/pos/simulator/view/pos/panels/POS.html
@@ -2,14 +2,15 @@
 
 <ul class="controllers">
   {#each MODELS as model}
-    <li class="controller {getSanitizedPosModel(model)}">
-      <span>{model}</span>
-      <Radio
-        name="model"
-        checked="{isModelChecked($ACTIVE_MODEL, model)}"
-        on:change="updateCapabilities()"
-        on:click="setPosModel(model)" />
-    </li>
+  <li class="controller {getSanitizedPosModel(model)}">
+    <span>{model}</span>
+    <Radio
+      name="model"
+      checked="{isModelChecked($ACTIVE_MODEL, model)}"
+      on:change="updateCapabilities()"
+      on:click="setPosModel(model)"
+    />
+  </li>
   {/each}
 
   <li class="controller is-full">
@@ -19,14 +20,9 @@
         <div class="box-status" class:active="!hasNoPrinter">Impressora</div>
         <div class="box-status" class:active="hasTouch">Touch</div>
         <div class="box-status" class:active="hasOnlyTouch">Apenas touch</div>
-        <div class="box-status" class:active="hasFunctionKeys">Teclas de <u>F</u>unções</div>
         <div class="box-status" class:active="hasKeyboardLight">Luz de teclado</div>
-        <div class="box-status" class:active="hasHighDPI">DPI alto</div>
         <div class="box-status" class:active="hasArrowNavigation">Navegação por setas</div>
         <div class="box-status" class:active="hasSmallScreen">Tela pequena</div>
-        <div class="box-status" class:active="isPAXDevices">Pax</div>
-        <div class="box-status" class:active="isGertecDevices">Gertec</div>
-        <div class="box-status" class:active="isVerifoneDevices">Verifone</div>
       </li>
     </ul>
   </li>

--- a/packages/pos/simulator/view/pos/panels/POS.html
+++ b/packages/pos/simulator/view/pos/panels/POS.html
@@ -72,17 +72,18 @@
       updateCapabilities() {
         setTimeout(() => {
           this.set({
+            hasPrinter: Device.hasPrinter(),
             hasNoPrinter: Device.hasNoPrinter(),
             hasTouch: Device.hasTouch(),
             hasOnlyTouch: Device.hasOnlyTouch(),
-            hasFunctionKeys: Device.hasFunctionKeys(),
+            hasNoTouch: Device.hasNoTouch(),
             hasKeyboardLight: Device.hasKeyboardLight(),
-            hasHighDPI: Device.hasHighDPI(),
             hasArrowNavigation: Device.hasArrowNavigation(),
             hasSmallScreen: Device.hasSmallScreen(),
-            isPAXDevices: Device.isPAXDevices(),
-            isGertecDevices: Device.isGertecDevices(),
-            isVerifoneDevices: Device.isVerifoneDevices(),
+            hasKeyboard: Device.hasKeyboard(),
+            hasEthernet: Device.hasEthernet(),
+            hasWifi: Device.hasWifi(),
+            hasGprs: Device.hasGprs(),
           });
         });
       },

--- a/packages/pos/simulator/view/pos/panels/POS.html
+++ b/packages/pos/simulator/view/pos/panels/POS.html
@@ -17,9 +17,10 @@
     <span>Capacidades do POS selecionado</span>
     <ul>
       <li>
-        <div class="box-status" class:active="!hasNoPrinter">Impressora</div>
+        <div class="box-status" class:active="hasPrinter">Impressora</div>
         <div class="box-status" class:active="hasTouch">Touch</div>
         <div class="box-status" class:active="hasOnlyTouch">Apenas touch</div>
+        <div class="box-status" class:active="hasKeyboard">Teclado</div>
         <div class="box-status" class:active="hasKeyboardLight">Luz de teclado</div>
         <div class="box-status" class:active="hasArrowNavigation">Navegação por setas</div>
         <div class="box-status" class:active="hasSmallScreen">Tela pequena</div>
@@ -71,12 +72,12 @@
             hasPrinter: Device.hasPrinter(),
             hasNoPrinter: Device.hasNoPrinter(),
             hasTouch: Device.hasTouch(),
-            hasOnlyTouch: Device.hasOnlyTouch(),
             hasNoTouch: Device.hasNoTouch(),
+            hasOnlyTouch: Device.hasOnlyTouch(),
+            hasKeyboard: Device.hasKeyboard(),
             hasKeyboardLight: Device.hasKeyboardLight(),
             hasArrowNavigation: Device.hasArrowNavigation(),
             hasSmallScreen: Device.hasSmallScreen(),
-            hasKeyboard: Device.hasKeyboard(),
             hasEthernet: Device.hasEthernet(),
             hasWifi: Device.hasWifi(),
             hasGprs: Device.hasGprs(),

--- a/packages/utils/models.js
+++ b/packages/utils/models.js
@@ -321,38 +321,44 @@ export function hasGprs() {
 
 /**
  * #####################
- * #### UNAVAILABLE ####
+ * #### DEPRECATED ####
  * #####################
  *
- * @description hasHighDPI and hasFunctionKeys works right now,
- *  but turned unavailable due to lack of use.
- *  Can be uncommented at any time!
+ * @description deprecated methods since @mamba/utils v6.0.0
+ *
  */
 
-//  * High DPI devices
-//  * @returns {array} A list of devices with high dpi
-//  */
-// export const HIGH_DPI_DEVICES = [MODELS.Q92, MODELS.D199];
+/**
+ * High DPI devices
+ *
+ * @description A list of devices with high dpi
+ * @returns {array}
+ */
+export const HIGH_DPI_DEVICES = [MODELS.Q92, MODELS.D199];
 
-// /**
-//  * @returns {boolean} If current model have a high DPI screen
-//  */
-// export function hasHighDPI() {
-//   return _hasModelAtList(HIGH_DPI_DEVICES);
-// }
+/**
+ * @description If current model have a high DPI screen
+ * @returns {boolean}
+ */
+export function hasHighDPI() {
+  return _hasModelAtList(HIGH_DPI_DEVICES);
+}
 
-// /**
-//  * Devices with Function Keys
-//  * @returns {array} A list of devices that have function keys
-//  */
-// export const FUNCTION_KEYS_DEVICES = [MODELS.MP35P, MODELS.MP35];
+/**
+ * Devices with Function Keys
+ *
+ * @description A list of devices that have function keys
+ * @returns {array}
+ */
+export const FUNCTION_KEYS_DEVICES = [MODELS.MP35P, MODELS.MP35];
 
-// /**
-//  * @returns {boolean} If current model have function keys
-//  */
-// export function hasFunctionKeys() {
-//   return _hasModelAtList(FUNCTION_KEYS_DEVICES);
-// }
+/**
+ * @description If current model have function keys
+ * @returns {boolean}
+ */
+export function hasFunctionKeys() {
+  return _hasModelAtList(FUNCTION_KEYS_DEVICES);
+}
 
 export function getDeviceCapabilitiesClassList() {
   return [
@@ -370,8 +376,8 @@ export function getDeviceCapabilitiesClassList() {
     hasEthernet() && 'has-ethernet',
     hasWifi() && 'has-wifi',
     hasGprs() && 'has-gprs',
-    // UNAVAILABLE
-    // hasFunctionKeys() && 'has-function-keys',
-    // hasHighDPI() && 'has-high-dpi',
+    // DEPRECATED
+    hasFunctionKeys() && 'has-function-keys',
+    hasHighDPI() && 'has-high-dpi',
   ].filter(Boolean);
 }


### PR DESCRIPTION
# Resumo
- Tornar recursos de POS obsoletos
- Atualizar painel de recursos no Simulador

# Ticket
- [[487260] [MambaSDK] Passar a ver os recursos do POS através do back](https://stonepagamentos.visualstudio.com/Tribo%20Meios%20de%20Pagamento/_workitems/edit/487260)
- [[487528] [Ativação] Aplicar novos métodos de recursos](https://stonepagamentos.visualstudio.com/Tribo%20Meios%20de%20Pagamento/_workitems/edit/487528)