### PR TITLE
512581 update methods utils

### DIFF
--- a/packages/utils/models.js
+++ b/packages/utils/models.js
@@ -183,7 +183,14 @@ export function isStandardModel() {
  * @returns {boolean} If the current model is from the PAX manufacturer
  */
 export function isPAXDevices() {
-  return _hasModelAtList(PAX_DEVICES);
+  let value = VerifyMethodOnSystemWrapper('getPosBrand');
+
+  if (typeof value === 'undefined') {
+    value = _hasModelAtList(PAX_DEVICES);
+    return value;
+  }
+
+  return value.toUpperCase() === 'PAX';
 }
 
 /**
@@ -199,7 +206,14 @@ export const VERIFONE_DEVICES = [MODELS.V240M];
  * @returns {boolean} If the current model is from the Verifone manufacturer
  */
 export function isVerifoneDevices() {
-  return _hasModelAtList(VERIFONE_DEVICES);
+  let value = VerifyMethodOnSystemWrapper('getPosBrand');
+
+  if (typeof value === 'undefined') {
+    value = _hasModelAtList(VERIFONE_DEVICES);
+    return value;
+  }
+
+  return value.toUpperCase() === 'VERIFONE';
 }
 
 /**
@@ -215,7 +229,14 @@ export const GERTEC_DEVICES = [MODELS.MP35, MODELS.MP35P];
  * @returns {boolean} If the current model is from the Gertec manufacturer
  */
 export function isGertecDevices() {
-  return _hasModelAtList(GERTEC_DEVICES);
+  let value = VerifyMethodOnSystemWrapper('getPosBrand');
+
+  if (typeof value === 'undefined') {
+    value = _hasModelAtList(GERTEC_DEVICES);
+    return value;
+  }
+
+  return value.toUpperCase() === 'GERTEC';
 }
 
 /**

--- a/packages/utils/models.js
+++ b/packages/utils/models.js
@@ -315,7 +315,7 @@ export function hasKeyboard() {
  * @description Devices with keyboard light
  * @returns {array} A list of devices that has keyboard light
  */
-export const HAS_KEYBOARD_LIGHT = [MODELS.MP35P, MODELS.D230];
+export const HAS_KEYBOARD_LIGHT = [MODELS.MP35P, MODELS.D230, MODELS.S920, MODELS.Q92, MODELS.Q92S];
 
 /**
  * @description If current model have keyboard light


### PR DESCRIPTION
# Resumo
- Rafael identificou que o fallback `HAS_KEYBOARD_LIGHT` estava faltando POSs que se adequavam ao filtro
- Em conversa com o Wellington de Plataforma, ele sugeriu o uso do método do back-end,  `getPosBrand()`, pra alimentar dinâmicamente métodos de fornecedor (`isPAXDevices()`, `isGertecDevices()`)

# Ticket
- [[512581] Atualizar hasKeyboardLight() e métodos de fornecedor](https://stonepagamentos.visualstudio.com/Tribo%20Meios%20de%20Pagamento/_workitems/edit/512581)