### PR TITLE
feat: Include button size input for CorfirmationDialog component

### DIFF
--- a/packages/components/Dialog/Confirmation.html
+++ b/packages/components/Dialog/Confirmation.html
@@ -28,7 +28,7 @@
             <div class="action" on:click="close('negative', 'touch')" shortcut="close">
               <RoundIcon
                 symbol="close"
-                size="giant"
+                size={buttonSize}
                 borderRadius="11px"
                 bgColor={red400}
               />
@@ -50,7 +50,7 @@
             <div class="action" on:click="close('positive', 'touch')" shortcut="enter">
               <RoundIcon
                 symbol="check"
-                size="giant"
+                size={buttonSize}
                 borderRadius="11px"
                 bgColor={green500}
               />
@@ -83,6 +83,7 @@
         positiveLabel: null,
         negativeLabel: null,
         primaryColor: green500,
+        buttonSize: 'giant',
       };
     },
     computed: {


### PR DESCRIPTION
## Descrição 

Esse PR faz a alteração do componente `CorfirmationDialog`, adicionando a variável `buttonSize`.

O objetivo é permitir que o app consumindo esse componente possa alterar o tamanho do botão utilizado. Essa alteração faz parte da correção do app DeviceTest, onde para POS de tela pequena, a tela do teste de leitura do cartão ficava recortada.

Card do bug: [501066](https://stonepagamentos.visualstudio.com/Tribo%20Meios%20de%20Pagamento/_boards/board/t/Mamba%20-%20Plataforma/Stories/?workitem=501066)

## Impacto

Essa modificação não deve gerar nenhum impacto no funcionamento dos apps que consomem esse componente, pois o valor padrão usado foi o mesmo que estava fixado anteriormente.