### PR TITLE
New static assets structure

### DIFF
--- a/packages/webpack/config.app.build.js
+++ b/packages/webpack/config.app.build.js
@@ -31,7 +31,7 @@ module.exports = merge(require('./config.app.js'), {
         copy: [
           {
             source: `./src/${PKG.mamba.iconPath}`,
-            destination: `./dist/${BUNDLE_NAME}/assets`,
+            destination: `./dist/${BUNDLE_NAME}/${PKG.mamba.iconPath}`,
           },
         ],
         archive: [

--- a/packages/webpack/helpers/consts.js
+++ b/packages/webpack/helpers/consts.js
@@ -22,7 +22,12 @@ if (env.APP_ENV === 'browser') {
   env.MAMBA_SIMULATOR = 'true';
 }
 
+if (typeof env.SDK_ASSETS_FOLDER === 'undefined') {
+  env.SDK_ASSETS_FOLDER = '@mamba';
+}
+
 module.exports = {
+  SDK_ASSETS_FOLDER: env.SDK_ASSETS_FOLDER,
   NODE_ENV: env.NODE_ENV,
   APP_ENV: env.APP_ENV,
   IS_PROD: env.NODE_ENV === 'production',

--- a/packages/webpack/helpers/loaders.js
+++ b/packages/webpack/helpers/loaders.js
@@ -6,7 +6,14 @@ const { extendPresetEnv } = require('@mamba/configs/babel/utils.js');
 /** Read the svelte config file from the project */
 const svelteConfig = require('@mamba/configs/svelte/index.js');
 
-const { IS_DEV } = require('./consts.js');
+const { IS_DEV, SDK_ASSETS_FOLDER } = require('./consts.js');
+
+function resolveFileLoaderName(resourcePath) {
+  if (/@mamba/.test(resourcePath)) {
+    return `${SDK_ASSETS_FOLDER}/[name].[ext][query]`;
+  }
+  return `[path][name].[ext][query]`;
+}
 
 const babelLoaderConfig = {
   loader: 'babel-loader',
@@ -63,8 +70,7 @@ module.exports = {
     options: {
       fallback: 'file-loader',
       limit: 1, // Copy font files instead of inserting them on the css
-      outputPath: 'assets/',
-      name: './fonts/[name].[ext]',
+      name: resolveFileLoaderName,
     },
   },
   images: {
@@ -72,8 +78,7 @@ module.exports = {
     options: {
       fallback: 'file-loader',
       limit: 1,
-      outputPath: 'assets/',
-      name: `./images/[name]${IS_DEV ? '.[hash:5]' : ''}.[ext]`,
+      name: resolveFileLoaderName,
     },
   },
   svelte: {


### PR DESCRIPTION
# Changes
* Resolve static assets to the same structure on bundle target folder.
* Ensure that app icon is copied to the same folder structure declared.
* Read `SDK_ASSETS_FOLDER` from envs, or keep default to `@mamba`