### PR TITLE
fix: 🐛 implementação de logica para colocar o padding-bottom quanto h…

### DIFF
--- a/packages/components/Flatlist/FlatList.html
+++ b/packages/components/Flatlist/FlatList.html
@@ -180,8 +180,12 @@
       // Watch for navbar changes after mount
       if (changed.navBar) {
         const { navBar } = this.refs;
+        const { dataSection } = current;
         if (current.navBar === true && navBar && typeof navBar.getBoundingHeight === 'function') {
-          this.set({ _extraBounds: navBar.getBoundingHeight() });
+          this.set({
+            _extraBounds:
+              dataSection && dataSection[0].data.length > 2 ? navBar.getBoundingHeight() : 0,
+          });
         } else {
           this.set({ _extraBounds: 0 });
         }
@@ -494,7 +498,10 @@
        */
       _onNavbarSetup(event) {
         const { boundingHeight = 0 } = event;
-        this.set({ _extraBounds: boundingHeight });
+        const { dataSection } = this.get();
+        this.set({
+          _extraBounds: dataSection && dataSection[0].data.length > 2 ? boundingHeight : 0,
+        });
       },
     },
   };


### PR DESCRIPTION
# Itens de trabalho

<!-- Preencha o link abaixo com o código e o link da tarefa no VSTS -->

[[PMIPA-337] - Tela inicial com logo cortado / sem aparecer e não está centralizado]https://mundipagg.atlassian.net/browse/PMIPA-337)

## Descrições

Descrição geral da tarefa: Conforme imagens em anexo, na D230 quando liga na tela de ativação não aparece o logo da Org, tem que rolar o scroll no touch para aparecer, os outros modelos tela pequena aparecem com logo cortado e desalinhados

## Instruções para testes

Usar o npm link (ou yarn link) para fazer o testa na ativação

## Checklist

- [x] Atualizar documentações (quando aplicável).
- [ ] Documentar / Oficializar Feature Flags(inclusive na [planilha](https://docs.google.com/spreadsheets/d/1uj2zDKpRbixLMGSYEpU6-2BeiMc7WGeQ-M6Fn2r6tp4/edit#gid=0)).
- [x] Divulgar o PR no canal e solicitar review.
- [ x Testar as alterações que fez (quando aplicável).
- [x] Garantir não haver erros de linter.
- [x] Garantir que a [pipeline](https://dev.azure.com/stonepagamentos/POS%20-%20Mamba/_build?definitionId=1992) esteja rodando e compilando as alterações.

## Checklist de Release

- [x] Comece a cometer correções de última hora na preparação de seu lançamento.
- [ ] Saltar a versão (bump version)