### PR TITLE
fix: 🐛 implementação de logica para colocar o padding-bottom quanto h…

### DIFF
--- a/packages/components/Flatlist/FlatList.html
+++ b/packages/components/Flatlist/FlatList.html
@@ -180,8 +180,12 @@
       // Watch for navbar changes after mount
       if (changed.navBar) {
         const { navBar } = this.refs;
+        const { dataSection } = current;
         if (current.navBar === true && navBar && typeof navBar.getBoundingHeight === 'function') {
-          this.set({ _extraBounds: navBar.getBoundingHeight() });
+          this.set({
+            _extraBounds:
+              dataSection && dataSection[0].data.length > 2 ? navBar.getBoundingHeight() : 0,
+          });
         } else {
           this.set({ _extraBounds: 0 });
         }
@@ -494,7 +498,10 @@
        */
       _onNavbarSetup(event) {
         const { boundingHeight = 0 } = event;
-        this.set({ _extraBounds: boundingHeight });
+        const { dataSection } = this.get();
+        this.set({
+          _extraBounds: dataSection && dataSection[0].data.length > 2 ? boundingHeight : 0,
+        });
       },
     },
   };


### PR DESCRIPTION
## Descrições

Descrição geral da tarefa: Conforme imagens em anexo, na D230 quando liga na tela de ativação não aparece o logo da Org, tem que rolar o scroll no touch para aparecer, os outros modelos tela pequena aparecem com logo cortado e desalinhados

## Instruções para testes

Usar o npm link (ou yarn link) para fazer o testa na ativação

## Checklist

- [x] Divulgar o PR no canal e solicitar review.
- [x] Testar as alterações que fez (quando aplicável).
- [x] Garantir não haver erros de linter.
