### PR TITLE
fix: missing comma that was breaking the bundle

### DIFF
--- a/packages/components/Icon/example/Example.html
+++ b/packages/components/Icon/example/Example.html
@@ -133,7 +133,7 @@
           'star-outline',
           'star',
           'wifi',
-          'wifi-off'
+          'wifi-off',
         ],
       };
     },


### PR DESCRIPTION
# Description


missing comma that was breaking the bundle

# Changes

The bundle was breaking due to a missing comma in the Example.html page
