### PR TITLE
Remove notice warning

### DIFF
--- a/packages/pos/simulator/view/pos/panels/Orgs.html
+++ b/packages/pos/simulator/view/pos/panels/Orgs.html
@@ -120,12 +120,6 @@
 </script>
 
 <style>
-  .notice {
-    display: none;
-    margin-top: 10px;
-    color: $neutral400;
-  }
-
   .org {
     color: $green500;
     font-weight: 600;


### PR DESCRIPTION
# Fix

Remove this linter warning of v10
<img width="737" alt="image" src="https://github.com/stone-payments/pos-mamba-sdk/assets/1163344/3cb25d0b-541a-4f5c-997c-86659a753576">
