### PR TITLE
fix: 🐛 remove the reset of the error message

### DIFF
--- a/packages/components/Input/Input.html
+++ b/packages/components/Input/Input.html
@@ -370,7 +370,6 @@
           if (validateOn === 'submit') {
             validationUpdate = {
               isValid: false,
-              _errorMsg: undefined,
             };
           }
 


### PR DESCRIPTION
## Descrições

- componente input possui os métodos padrões para mostrar erro caso o campos esteja inválido

- num cenário onde tentamos sequencialmente validar um campo, debugamos e vimos que o aviso de erro some - o campo é validado - e caso erro ele reaparece, porém isso é muito rápido

- no meio disso o campo mostra a borda inferior verde padrão, com um aparente delay, o que faz com que em muitos casos fiquemos com duas bordas (uma vermelha e uma verde, sendo essa por cima do aviso de erro)

## Instruções para testes

Usar o npm link (ou yarn link) para fazer o testa no pagamento

## Checklist

- [x] Divulgar o PR no canal e solicitar review.
- [x] Testar as alterações que fez (quando aplicável).
- [] Garantir não haver erros de linter.
