### PR TITLE
Bug/pmipa 1485 sdk input delay

### DIFF
--- a/packages/components/Input/Input.html
+++ b/packages/components/Input/Input.html
@@ -1,12 +1,6 @@
-<label
-  class="input type-{type}"
-  class:is-readable="readable"
-  class:is-invalid="!isValid && !!_errorMsg"
-  class:is-focused="isFocused"
-  class:is-compact="compact"
-  class:has-password-toggle="_hasPasswordToggle"
-  style="background-color: {bgColor}; color: {labelColor};"
->
+<label class="input type-{type}" class:is-readable="readable" class:is-invalid="!isValid && !!_errorMsg"
+  class:is-focused="isFocused" class:is-compact="compact" class:has-password-toggle="_hasPasswordToggle"
+  style="background-color: {bgColor}; color: {labelColor};">
   {#if label}
     <span class="label">{label}</span>
   {/if}
@@ -370,7 +364,6 @@
           if (validateOn === 'submit') {
             validationUpdate = {
               isValid: false,
-              _errorMsg: undefined,
             };
           }
 

--- a/packages/components/Input/Input.html
+++ b/packages/components/Input/Input.html
@@ -1,6 +1,12 @@
-<label class="input type-{type}" class:is-readable="readable" class:is-invalid="!isValid && !!_errorMsg"
-  class:is-focused="isFocused" class:is-compact="compact" class:has-password-toggle="_hasPasswordToggle"
-  style="background-color: {bgColor}; color: {labelColor};">
+<label
+  class="input type-{type}"
+  class:is-readable="readable"
+  class:is-invalid="!isValid && !!_errorMsg"
+  class:is-focused="isFocused"
+  class:is-compact="compact"
+  class:has-password-toggle="_hasPasswordToggle"
+  style="background-color: {bgColor}; color: {labelColor};"
+>
   {#if label}
     <span class="label">{label}</span>
   {/if}


### PR DESCRIPTION
## Descrições

- componente input possui os métodos padrões para mostrar erro caso o campos esteja inválido

- num cenário onde tentamos sequencialmente validar um campo, debugamos e vimos que o aviso de erro some - o campo é validado - e caso erro ele reaparece, porém isso é muito rápido

- no meio disso o campo mostra a borda inferior verde padrão, com um aparente delay, o que faz com que em muitos casos fiquemos com duas bordas (uma vermelha e uma verde, sendo essa por cima do aviso de erro)

## Instruções para testes

Usar o npm link (ou yarn link) para fazer o testa no pagamento

## Checklist

- [x] Divulgar o PR no canal e solicitar review.
- [x] Testar as alterações que fez (quando aplicável).
- [x] Garantir não haver erros de linter.
