### PR TITLE
Update immer

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "eslint": "^7.0.0",
     "git-cz": "^3.0.0",
     "husky": "^1.3.1",
-    "immer": "^2.1.5",
     "jest": ">=28.0.0 <29.0.0-0",
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "28.1.0",

--- a/packages/pos/package.json
+++ b/packages/pos/package.json
@@ -23,7 +23,7 @@
     "@mamba/sprite": "^10.0.0",
     "@mamba/switch": "^10.0.0",
     "@mamba/utils": "^10.0.0",
-    "immer": "^2.1.5",
+    "immer": "^10.0.2",
     "lodash": "^4.17.21",
     "svelte": "<3"
   },

--- a/packages/pos/simulator/plugins/registry/includes/data.js
+++ b/packages/pos/simulator/plugins/registry/includes/data.js
@@ -1,6 +1,7 @@
-import produce, { applyPatches } from 'immer';
-
+import { produce, applyPatches, enablePatches } from 'immer';
 import { log, warn } from '../../../libs/utils.js';
+
+enablePatches();
 
 export default (Registry) => {
   Registry._data = Object.freeze({});

--- a/packages/pos/simulator/plugins/registry/includes/persistent.js
+++ b/packages/pos/simulator/plugins/registry/includes/persistent.js
@@ -1,4 +1,4 @@
-import produce, { applyPatches } from 'immer';
+import { produce, applyPatches } from 'immer';
 import { warn } from '../../../libs/utils.js';
 
 let cachedGet = null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8112,10 +8112,10 @@ ignore@^5.0.2, ignore@^5.2.0, ignore@^5.2.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immer@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-2.1.5.tgz#0389947455c5a2c7a47f1e6f415c9d1a62a1ebed"
-  integrity sha512-xyjQyTBYIeiz6jd02Hg12jV+9QISwF1crLcwTlzHpWH4e0ryNWj1kacpTwimK3bJV5NKKXw458G2vpqoB/inFA==
+immer@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.0.2.tgz#11636c5b77acf529e059582d76faf338beb56141"
+  integrity sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
# Fix
`Immer` 10x with reported security fixes:
<img width="897" alt="image" src="https://github.com/stone-payments/pos-mamba-sdk/assets/1163344/5844c6b6-3ff7-4796-8f3f-bfbdff7c3eaa">
