### PR TITLE
bug/PMIPA-2110-hide-input-error-when-type

### DIFF
--- a/packages/components/Input/Input.html
+++ b/packages/components/Input/Input.html
@@ -357,6 +357,8 @@
         }
       },
       _onInput(e) {
+        const keyCode = Keyboard.parseEventKeyCode(e);
+
         const { validation, validateOn } = this.get();
 
         /** Mask handler */
@@ -367,9 +369,9 @@
           let validationUpdate = validationUpdateMask;
 
           /** If validation is on submit, reset the validation state */
-          if (validateOn === 'submit') {
+          if (validateOn === 'submit' && keyCode !== KEYBOARD.ENTER) {
             validationUpdate = {
-              isValid: false,
+              isValid: true,
             };
           }
 


### PR DESCRIPTION
## Descrições

- componente input quando está com a prop `validateOn === 'submit'` remove o erro quando um novo valor é digitado

## Instruções para testes

Usar o npm link (ou yarn link) para fazer o testa no pagamento

## Checklist

- [x] Divulgar o PR no canal e solicitar review.
- [x] Testar as alterações que fez (quando aplicável).
- [x] Garantir não haver erros de linter.
