### PR TITLE
failure print dialog without appbar

### DIFF
--- a/packages/components/Printable/Printable.html
+++ b/packages/components/Printable/Printable.html
@@ -20,6 +20,7 @@
   <Dialog
     ref:failureDialog
     on:close="fire('finish', true)"
+    fullscreen
   >
       <img class="failure-dialog-icon" src={alertIcon} alt="" />
       <h1 class="title-dialog">ERRO NA IMPRESSÃO</h1>


### PR DESCRIPTION
## Descrições
Adiciona a propriedade `fullscreen` para o `Dialog` de erro de impressão no componente `Printable`.

## Checklist
- [x] Divulgar o PR no canal e solicitar review.
- [x] Testar as alterações que fez (quando aplicável).
- [x] Garantir não haver erros de linter.
