### PR TITLE
fix: remove clear input listener action on reset

### DIFF
--- a/packages/components/Keyboard/src/Keyboard.ts
+++ b/packages/components/Keyboard/src/Keyboard.ts
@@ -809,13 +809,6 @@ class Keyboard {
     }
 
     /**
-     *  Clear input listeners for keyboard route reset
-     */
-    if (this.physicalKeyboard) {
-      this.physicalKeyboard.clearInputListeners();
-    }
-
-    /**
      * Reset input value
      */
     this.setInput('');


### PR DESCRIPTION
## Descrições
Remove a ação `this.physicalKeyboard.clearInputListeners()` quando o keyboard for resetado, mantendo somente no `destroy`.

## Checklist
- [x] Divulgar o PR no canal e solicitar review.
- [x] Testar as alterações que fez (quando aplicável).
- [x] Garantir não haver erros de linter.
