### PR TITLE
Add slot before title on Dialog

### DIFF
--- a/packages/components/Dialog/Dialog.html
+++ b/packages/components/Dialog/Dialog.html
@@ -10,6 +10,9 @@
     on:keyup
   >
     <div class="content -align-{align}" style={_contentStyle}>
+      <div class="begin">
+        <slot name="begin"></slot>
+      </div>
       <div class="message">
         {#if title}
           <div class="title">{title}</div>


### PR DESCRIPTION
### Descrição

Foi implementado ao componente `Dialog` a opção de adicionar qualquer elemento antes do título, tornando este componente mais adaptável aos estilos.

### Card
A demanda deste [card](https://mundipagg.atlassian.net/browse/PMIPA-5576) motivou a implementação deste PR.