### PR TITLE
Change useBuiltIns on babel config

### DIFF
--- a/packages/configs/babel/template.js
+++ b/packages/configs/babel/template.js
@@ -3,7 +3,7 @@ const generalConfig = require('./index.js');
 const { extendPresetEnv } = require('./utils.js');
 
 const config = extendPresetEnv(generalConfig, {
-  useBuiltIns: 'usage',
+  useBuiltIns: 'entry',
   corejs: { version: 3, proposals: true },
   exclude: [
     'es.string.anchor', // Not used


### PR DESCRIPTION
# Descrição

Resolve o problema do import `regenerator-runtime/runtime` em todos os builds das aplicações.
Documentação de apoio: https://babeljs.io/docs/babel-preset-env#usebuiltins-entry

# Checklist

<!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->

- [ ] Testei as alterações localmente.
- [ ] Atualizei qualquer documentação relevante.
- [ ] Verifiquei que não há problemas de Lint ou formatação.
- [ ] Confirmei que o código segue as diretrizes de contribuição do projeto.
