### PR TITLE
PMIPA-11171 - Improove repo_setup to avoid unecessary toolchain download

### DIFF
--- a/tools/repo_setup.py
+++ b/tools/repo_setup.py
@@ -423,16 +423,17 @@ class PosMambaRepoSetup:
             f"--path {self.download_dir}"
         ]
 
-        config = configparser.ConfigParser()
-        config.read(artifact_version_file_path)
-
         if os.path.isfile(artifact_version_file_path):
+            config = configparser.ConfigParser()
+            config.read(artifact_version_file_path)
             current_version = config.get(artifact, "version")
             if current_version == version:
                 print_color(f"Artifact {artifact} already exists and is updated. Skipping download.", GREEN)
                 return
             else:
                 print_color(f"Current {artifact} version: {current_version}. Will update to {version}.", BLUE)
+        else:
+            print_color(f"Version file '.package.ini' not found. Will download {version}.", YELLOW)
 
         try:
             tar_file_path = os.path.join(self.download_dir, file_name)

--- a/tools/repo_setup.py
+++ b/tools/repo_setup.py
@@ -421,6 +421,12 @@ class PosMambaRepoSetup:
             f"--path {self.download_dir}"
         ]
 
+        ndk26_path = os.path.join(full_repo_path, f"toolchain_ndk26")
+
+        if os.path.exists(ndk26_path):
+            print(f"Toolchain NDK26 already exists. Skipping download.")
+            return
+
         try:
             tar_file_path = os.path.join(self.download_dir, file_name)
 


### PR DESCRIPTION
# Descrição

<!-- Por favor, forneça abaixo uma breve descrição das mudanças incluídas neste Pull Request -->

Este PR ajusta o download da toolchain ndk26 da gertec ao rodar o repo_setup para não realizá-lo de forma desnecessária, acrescentando uma verificação se a toolchain já existe na pasta do mal.

Atualmente, sempre que o `repo_setup.py` é executado (tanto manualmente quanto ao trocar de branch), caso haja algum artifact descrito no `repo_settings.json`, é verificado se o mesmo já foi baixado em momentos anteriores, porém a verificação era feita da seguinte forma: o script olhava na pasta de download dos artifacts se ele existia e, caso não existisse, baixava e instalava o artifact no repositório, de acordo com as informações presentes no arquivo `repo_settings.json`.

Desta forma, sempre que a pasta de `output` era apagada (sempre que roda o script de build com a opção `-r`, a pasta é apagada), ao fazer checkout em outra branch, o arquivo era baixado novamente sem a necessidade.

Portanto, a proposta trazida neste PR é que não verifique mais a pasta de output, mas sim um arquivo `.downloaded_artifacts.ini`que **só é criado caso o repositório possua artifacts descritos no `repo_settings.json` para serem baixados**, mantendo inclusive a ultima versão baixada.

O funcionamento do script é o seguinte:
```mermaid
graph LR
    A[repo_setup.py é executado] --> B[Atualiza submodules];

    B --> C{Existe artifacts para download em repo_settings.json?};
    C -- Não --> D[Finaliza Script];

    C -- Sim --> E{Existe .downloaded_artifacts.ini?};
    E -- Não --> F[Cria .downloaded_artifacts.ini com versão do artifact a ser baixado = 'none'];

    E -- Sim --> G{Versão do artifact a baixar == versão em .downloaded_artifacts.ini?};
    F --> G;

    G -- Sim --> D;

    G -- Não --> H[Realiza download e extração do novo artifact];
    H --> I[Atualiza versão em .downloaded_artifacts.ini];
    I --> D;
```

[PMIPA-11171](https://allstone.atlassian.net/browse/PMIPA-11171)
---

# Checklist

<!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->

- [ ] Testei as alterações localmente.
- [ ] Atualizei qualquer documentação relevante.
- [ ] Verifiquei que não há problemas de Lint ou formatação.
- [ ] Confirmei que o código segue as diretrizes de contribuição do projeto.


[PMIPA-11171]: https://allstone.atlassian.net/browse/PMIPA-11171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ